### PR TITLE
feat: padronizar status overdue para Vencido em PT-BR

### DIFF
--- a/aesthera/apps/web/app/(dashboard)/billing/page.tsx
+++ b/aesthera/apps/web/app/(dashboard)/billing/page.tsx
@@ -21,7 +21,7 @@ function formatDate(iso: string | null) {
 const STATUS_LABEL: Record<BillingStatus, string> = {
   pending: 'Pendente',
   paid: 'Pago',
-  overdue: 'Em atraso',
+  overdue: 'Vencido',
   cancelled: 'Cancelado',
 }
 
@@ -124,7 +124,7 @@ export default function BillingPage() {
     { value: '', label: 'Todos' },
     { value: 'pending', label: 'Pendente' },
     { value: 'paid', label: 'Pago' },
-    { value: 'overdue', label: 'Em atraso' },
+    { value: 'overdue', label: 'Vencido' },
     { value: 'cancelled', label: 'Cancelado' },
   ]
 

--- a/ai-engineering/projects/aesthera/PLAN.md
+++ b/ai-engineering/projects/aesthera/PLAN.md
@@ -213,6 +213,20 @@ abrir o navegador e usar o que foi construído. Nenhuma fase entrega só código
 
 ---
 
+## FASE 1 — Fundação (Base do Sistema)
+
+> Issues criadas a partir do roadmap (#42–#49). Itens de padronização e qualidade do sistema.
+
+- [x] #42 — Padronizar nomenclaturas do sistema para Português do Brasil (`overdue: 'Vencido'` em billing/page.tsx; auditoria confirmou todos os demais textos já em PT-BR)
+- [ ] #44 — Revisar e simplificar lógica de resolução de slug (tenant)
+- [ ] #45 — Exibir clínica e usuário logado no header/sidebar
+- [ ] #46 — Controle de acesso por perfil de usuário no frontend
+- [ ] #47 — Auto-preenchimento de endereço por CEP (ViaCEP)
+- [ ] #48 — Máscaras de entrada para CPF, CNPJ, telefone e CEP
+- [ ] #49 — Cadastro e configuração de formas de pagamento da clínica
+
+---
+
 ## Fase 10 — Pendente / Não implementado
 
 > Itens identificados no código ou features que ainda não foram construídos.


### PR DESCRIPTION
## Descrição

Auditoria completa de todos os textos visíveis ao usuário no frontend do dashboard. Todos os textos já estavam em PT-BR, exceto a label do status `overdue` em cobranças.

## Mudanças

- `billing/page.tsx`: status `overdue` renomeado de `Em atraso` para `Vencido` (tanto no `STATUS_LABEL` quanto no filtro de status)
- `PLAN.md`: seção FASE 1 adicionada com o item #42 marcado como concluído

Closes #42