### PR TITLE
feat: remover campo CNPJ da tela de cadastro de empresa

### DIFF
--- a/aesthera/apps/web/app/(auth)/register/page.tsx
+++ b/aesthera/apps/web/app/(auth)/register/page.tsx
@@ -3,7 +3,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import type { ChangeEvent } from 'react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -26,15 +25,6 @@ function slugifyPreview(name: string): string {
     .substring(0, 60)
 }
 
-function applyCnpjMask(value: string): string {
-  const digits = value.replace(/\D/g, '').substring(0, 14)
-  if (digits.length <= 2) return digits
-  if (digits.length <= 5) return `${digits.slice(0, 2)}.${digits.slice(2)}`
-  if (digits.length <= 8) return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5)}`
-  if (digits.length <= 12) return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8)}`
-  return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12)}`
-}
-
 const passwordSchema = z
   .string()
   .min(8, 'Senha deve ter ao menos 8 caracteres')
@@ -44,10 +34,6 @@ const passwordSchema = z
 
 const registerSchema = z
   .object({
-    clinicDocument: z.string().refine((value: string) => {
-      const digits = value.replace(/\D/g, '')
-      return digits.length === 0 || digits.length === 14
-    }, 'Informe um CNPJ válido com 14 dígitos ou deixe em branco.'),
     clinicName: z.string().min(2, 'Nome da clínica deve ter ao menos 2 caracteres'),
     adminName: z.string().min(2, 'Seu nome deve ter ao menos 2 caracteres'),
     email: z.string().email('E-mail inválido'),
@@ -70,21 +56,13 @@ export default function RegisterPage() {
     register,
     handleSubmit,
     watch,
-    setValue,
     formState: { errors },
   } = useForm<RegisterData>({
     resolver: zodResolver(registerSchema),
-    defaultValues: { clinicDocument: '' },
   })
 
   const clinicName = watch('clinicName') ?? ''
-  const clinicDocument = watch('clinicDocument') ?? ''
   const slugPreview = clinicName.length >= 2 ? slugifyPreview(clinicName) : ''
-  const clinicDocumentField = register('clinicDocument')
-
-  function handleCnpjChange(event: ChangeEvent<HTMLInputElement>) {
-    setValue('clinicDocument', applyCnpjMask(event.target.value), { shouldValidate: true })
-  }
 
   async function onSubmit(data: RegisterData) {
     setLoading(true)
@@ -98,7 +76,6 @@ export default function RegisterPage() {
         transferPending?: boolean
       }>('/auth/register', {
         clinicName: data.clinicName,
-        clinicDocument: data.clinicDocument || undefined,
         adminName: data.adminName,
         email: data.email,
         password: data.password,
@@ -135,22 +112,6 @@ export default function RegisterPage() {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="clinicDocument">CNPJ da empresa (opcional)</Label>
-            <Input
-              id="clinicDocument"
-              name={clinicDocumentField.name}
-              ref={clinicDocumentField.ref}
-              value={clinicDocument}
-              onChange={handleCnpjChange}
-              placeholder="00.000.000/0000-00"
-            />
-            <p className="text-xs text-muted-foreground">
-              Você pode preencher depois em Configurações. Se informar agora, validaremos apenas o formato.
-            </p>
-            {errors.clinicDocument && <p className="text-sm text-destructive">{errors.clinicDocument.message}</p>}
-          </div>
-
           <div className="space-y-2">
             <Label htmlFor="clinicName">Nome da clínica</Label>
             <Input id="clinicName" placeholder="Clínica Estética" {...register('clinicName')} />

--- a/ai-engineering/projects/aesthera/PLAN.md
+++ b/ai-engineering/projects/aesthera/PLAN.md
@@ -279,6 +279,13 @@ abrir o navegador e usar o que foi construído. Nenhuma fase entrega só código
 
 ---
 
+### [2026-03-20] — #54 — Remoção do campo CNPJ da tela de cadastro de empresa
+- **Arquivo(s) afetado(s):** aesthera/apps/web/app/(auth)/register/page.tsx, ai-engineering/projects/aesthera/features/auth-refactor-cnpj-login.md
+- **O que foi feito:** Removido completamente o campo CNPJ (label, Input, máscara, validação Zod, handlers e payload) do formulário `/register`. Backend `auth.dto.ts` já estava plenamente compatível com `undefined` no campo `clinicDocument`. Spec da feature atualizada na seção 2a para refletir a nova decisão.
+- **Impacto:** Onboarding simplificado — empresa pode ser criada sem CNPJ e preencher depois em Configurações.
+
+---
+
 ## Como usar este plano com o Copilot
 
 Ao iniciar uma fase, abra a sessão assim:

--- a/ai-engineering/projects/aesthera/features/auth-refactor-cnpj-login.md
+++ b/ai-engineering/projects/aesthera/features/auth-refactor-cnpj-login.md
@@ -35,16 +35,18 @@ Refatorar o fluxo de cadastro de empresa e autenticação em quatro frentes prin
 
 ### 2a — No cadastro de empresa (tela de registro)
 
-**Situação atual:**
-- Campo `clinicDocument` (CNPJ) no `RegisterClinicDto` é **opcional** (`z.string().min(14).max(18).optional()`)
-- No Prisma: `document String?` na tabela `clinics` — sem constraint `@unique`
-- Não há validação de formato nem unicidade
+**Decisão atualizada (issue #54 — implementado em 2026-03-20):**
+O campo CNPJ foi **removido completamente** do formulário `/register`. O CNPJ deve ser informado apenas na tela de Configurações, após o primeiro acesso. Isso elimina uma barreira desnecessária no onboarding.
 
-**Mudança desejada:**
-- CNPJ **não é obrigatório** no cadastro — o campo permanece opcional na tela de registro
-- Se informado no cadastro, validar apenas o formato (`XX.XXX.XXX/XXXX-XX` ou 14 dígitos) — **sem** validar dígito verificador e **sem** consultar a Receita Federal neste momento
-- Remover qualquer validação de unicidade de CNPJ no fluxo de cadastro (a constraint `@unique` não deve ser adicionada agora — CNPJ `null` múltiplo é permitido)
-- Tela de cadastro: campo CNPJ **opcional**, com máscara `XX.XXX.XXX/XXXX-XX`
+**Estado atual (pós-implementação):**
+- Campo `clinicDocument` **não existe mais** no formulário de cadastro (`register/page.tsx`)
+- `RegisterClinicDto` no backend permanece com o campo como opcional (`optionalCnpjSchema`) — aceita `undefined` sem erro
+- No Prisma: `document String?` na tabela `clinics` — sem constraint `@unique` (sem alteração)
+- `applyCnpjMask`, `handleCnpjChange` e toda lógica relacionada foram removidos do frontend
+
+**Fora do escopo (não fazer no cadastro):**
+- Não validar CNPJ no cadastro (campo não existe mais)
+- Não adicionar constraint `@unique` no cadastro
 
 ### 2b — Nas Configurações da empresa (após login)
 


### PR DESCRIPTION
## Descrição

Remove completamente o campo CNPJ do formulário de cadastro de empresa (`/register`), eliminando uma barreira desnecessária no onboarding. O CNPJ passa a ser informado exclusivamente na tela de Configurações, após o primeiro acesso.

## O que foi alterado

### Frontend
- `aesthera/apps/web/app/(auth)/register/page.tsx`
  - Removido campo `clinicDocument` (Label, Input, máscara, texto auxiliar e erro)
  - Removida função `applyCnpjMask`
  - Removido handler `handleCnpjChange`
  - Removido campo `clinicDocument` do schema Zod `registerSchema`
  - Removidos `watch('clinicDocument')` e `clinicDocumentField`
  - Removido `clinicDocument: data.clinicDocument || undefined` do payload enviado à API
  - Removidos `setValue` e `defaultValues: { clinicDocument: '' }` do `useForm`

### Backend
- `aesthera/apps/api/src/modules/auth/auth.dto.ts` — **sem alterações necessárias**. O campo `clinicDocument` já usa `optionalCnpjSchema` com `.optional()`, aceitando `undefined` sem erro de validação.

### Documentação
- `ai-engineering/projects/aesthera/features/auth-refactor-cnpj-login.md` — seção 2a atualizada para refletir a decisão de remoção
- `ai-engineering/projects/aesthera/PLAN.md` — entrada de histórico adicionada

## Critérios de Aceitação

- [x] O campo CNPJ não aparece mais em nenhuma parte do formulário `/register`
- [x] O cadastro funciona normalmente sem informar CNPJ
- [x] Nenhum erro de validação relacionado a `clinicDocument` ocorre ao submeter sem o campo
- [x] A tela de Configurações ainda exibe e permite preencher o CNPJ (não alterada)

## Fora do Escopo

- Lógica de CNPJ nas Configurações não foi alterada
- `normalizeCnpj` e demais lógicas no serviço de auth não foram alteradas
- Campo `clinicDocument` no banco de dados/Prisma schema não foi removido
- Endpoint `POST /auth/register` não foi alterado

Closes #54