### PR TITLE
chore(design-system): migrar status-colors.ts para padrão sólido (text-white)

### DIFF
--- a/aesthera/apps/api/src/modules/anamnesis/anamnesis.repository.ts
+++ b/aesthera/apps/api/src/modules/anamnesis/anamnesis.repository.ts
@@ -10,7 +10,7 @@ export class AnamnesisRepository {
   async create(
     clinicId: string,
     createdByUserId: string,
-    data: CreateAnamnesisRequestDto & { signToken: string; expiresAt: Date },
+    data: CreateAnamnesisRequestDto & { signToken: string; expiresAt: Date; status?: string },
   ) {
     return prisma.anamnesisRequest.create({
       data: {
@@ -24,6 +24,7 @@ export class AnamnesisRepository {
         staffAnswers: data.staffAnswers != null ? (data.staffAnswers as Prisma.InputJsonValue) : Prisma.JsonNull,
         signToken: data.signToken,
         expiresAt: data.expiresAt,
+        ...(data.status ? { status: data.status as never } : {}),
       },
       // SEC2: select explícito — signToken, signatureUrl, consentText, ipAddress, userAgent NUNCA retornados
       select: {

--- a/aesthera/apps/api/src/modules/anamnesis/anamnesis.service.ts
+++ b/aesthera/apps/api/src/modules/anamnesis/anamnesis.service.ts
@@ -75,15 +75,17 @@ export class AnamnesisService {
   async create(clinicId: string, userId: string, data: CreateAnamnesisRequestDto) {
     const signToken = generateSignToken()
     const expiresAt = buildExpiresAt()
+    const willSend = Boolean(data.phone || data.email)
 
     const request = await this.repo.create(clinicId, userId, {
       ...data,
       signToken,
       expiresAt,
+      status: willSend ? 'sent_to_client' : undefined,
     })
 
     // Envio assíncrono — não bloqueia a resposta
-    if (data.phone || data.email) {
+    if (willSend) {
       // SEC2: signToken passado da variável local — não vem do objeto `request` (que não o expõe)
       this.#sendNotification(clinicId, { ...request, signToken }, { phone: data.phone, email: data.email }).catch((err) =>
         logger.error({ err, requestId: request.id }, 'Falha ao enviar notificação de anamnese'),

--- a/aesthera/apps/web/components/anamnesis/AnamnesisTab.tsx
+++ b/aesthera/apps/web/components/anamnesis/AnamnesisTab.tsx
@@ -12,6 +12,7 @@ import { DataPagination } from '@/components/ui/data-pagination'
 import {
   type AnamnesisRequest,
   type AnamnesisRequestStatus,
+  useAnamnesisRequestById,
   useAnamnesisRequests,
   useCancelAnamnesis,
   useFinalizeAnamnesis,
@@ -75,6 +76,9 @@ export function AnamnesisTab({
   const cancelAnamnesis = useCancelAnamnesis()
   const finalizeAnamnesis = useFinalizeAnamnesis()
   const sendAnamnesis = useSendAnamnesis()
+
+  // Carrega o registro completo ao abrir o diff (list items não têm questionsSnapshot/staffAnswers/clientAnswers)
+  const { data: diffReqFull, isLoading: diffLoading } = useAnamnesisRequestById(diffReq?.id ?? null)
 
   function openSendDialog(id: string, mode: 'blank' | 'prefilled') {
     setSendingId(id)
@@ -490,12 +494,18 @@ export function AnamnesisTab({
             <DialogTitle className="mb-0 text-sm">Revisar respostas — {diffReq.groupName}</DialogTitle>
           </div>
           <div className="p-4 overflow-y-auto max-h-[70vh]">
-            <AnamnesisDiffViewer
-              anamnesisId={diffReq.id}
-              entries={buildDiffEntries(diffReq)}
-              onResolved={() => setDiffReq(null)}
-              onCancel={() => setDiffReq(null)}
-            />
+            {diffLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <AnamnesisDiffViewer
+                anamnesisId={diffReq.id}
+                entries={diffReqFull ? buildDiffEntries(diffReqFull) : []}
+                onResolved={() => setDiffReq(null)}
+                onCancel={() => setDiffReq(null)}
+              />
+            )}
           </div>
         </Dialog>
       )}

--- a/aesthera/apps/web/components/anamnesis/AnamnesisTab.tsx
+++ b/aesthera/apps/web/components/anamnesis/AnamnesisTab.tsx
@@ -1,9 +1,13 @@
 'use client'
 
 import { useState } from 'react'
-import { Ban, ClipboardList, Eye, Loader2, Plus, Send } from 'lucide-react'
+import { Ban, ClipboardList, Eye, Loader2, Mail, MessageCircle, Plus, Save, Send } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { PhoneInput } from '@/components/ui/phone-input'
 import { DataPagination } from '@/components/ui/data-pagination'
 import {
   type AnamnesisRequest,
@@ -38,7 +42,7 @@ interface Props {
 
 export function AnamnesisTab({
   customerId,
-  customerName: _customerName,
+  customerName,
   defaultPhone,
   defaultEmail,
   onCreateNew,
@@ -48,9 +52,15 @@ export function AnamnesisTab({
   const [statusFilter, setStatusFilter] = useState<AnamnesisRequestStatus | ''>('')
   const [diffReq, setDiffReq] = useState<AnamnesisRequest | null>(null)
   const [sendingId, setSendingId] = useState<string | null>(null)
+  const [sendingMode, setSendingMode] = useState<'blank' | 'prefilled'>('blank')
+  const [dispatchMode, setDispatchMode] = useState<'send' | 'save'>('send')
   const [cancelConfirmId, setCancelConfirmId] = useState<string | null>(null)
   const [sendPhone, setSendPhone] = useState('')
+  const [sendPhoneValid, setSendPhoneValid] = useState(false)
+  const [sendPhoneError, setSendPhoneError] = useState('')
   const [sendEmail, setSendEmail] = useState('')
+  const [sendViaWhatsapp, setSendViaWhatsapp] = useState(true)
+  const [sendViaEmail, setSendViaEmail] = useState(true)
 
   const role = useRole()
   const pageSize = 10
@@ -65,6 +75,46 @@ export function AnamnesisTab({
   const cancelAnamnesis = useCancelAnamnesis()
   const finalizeAnamnesis = useFinalizeAnamnesis()
   const sendAnamnesis = useSendAnamnesis()
+
+  function openSendDialog(id: string, mode: 'blank' | 'prefilled') {
+    setSendingId(id)
+    setSendingMode(mode)
+    setDispatchMode('send')
+    setSendPhone(defaultPhone ?? '')
+    setSendPhoneValid(false)
+    setSendPhoneError('')
+    setSendEmail(defaultEmail ?? '')
+    setSendViaWhatsapp(Boolean(defaultPhone))
+    setSendViaEmail(Boolean(defaultEmail))
+  }
+
+  function resetSendDialog() {
+    setSendingId(null)
+    setSendPhone('')
+    setSendPhoneValid(false)
+    setSendPhoneError('')
+    setSendEmail('')
+    setSendViaWhatsapp(true)
+    setSendViaEmail(true)
+  }
+
+  function handleSendPhoneChange(e164: string, isValid: boolean) {
+    setSendPhone(e164)
+    setSendPhoneValid(isValid)
+    if (e164.replace(/\D/g, '').length > 2) {
+      setSendPhoneError(isValid ? '' : 'Número inválido — verifique o DDD e os dígitos')
+    } else {
+      setSendPhoneError('')
+    }
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  const canSendNow = (() => {
+    if (!sendViaWhatsapp && !sendViaEmail) return false
+    if (sendViaWhatsapp && !sendPhoneValid) return false
+    if (sendViaEmail && !emailRegex.test(sendEmail.trim())) return false
+    return true
+  })()
 
   async function handleCancel(id: string) {
     try {
@@ -86,11 +136,13 @@ export function AnamnesisTab({
 
   async function handleSend(id: string) {
     try {
-      await sendAnamnesis.mutateAsync({ id, phone: sendPhone || undefined, email: sendEmail || undefined })
+      await sendAnamnesis.mutateAsync({
+        id,
+        phone: sendViaWhatsapp ? sendPhone : undefined,
+        email: sendViaEmail ? sendEmail.trim() : undefined,
+      })
       toast.success('Ficha enviada ao cliente.')
-      setSendingId(null)
-      setSendPhone('')
-      setSendEmail('')
+      resetSendDialog()
     } catch {
       toast.error('Erro ao enviar. Tente novamente.')
     }
@@ -207,7 +259,7 @@ export function AnamnesisTab({
                     variant="outline"
                     size="sm"
                     className="h-6 px-2 text-[10px]"
-                    onClick={() => { setSendingId(req.id); setSendPhone(defaultPhone ?? ''); setSendEmail(defaultEmail ?? '') }}
+                    onClick={() => openSendDialog(req.id, req.mode)}
                   >
                     <Send className="h-3 w-3" />
                     Enviar ao cliente
@@ -255,55 +307,146 @@ export function AnamnesisTab({
         />
       )}
 
-      {/* Dialog de envio ao cliente */}
+      {/* Dialog "O que fazer com a ficha?" */}
       {sendingId && (
-        <Dialog open onClose={() => { setSendingId(null); setSendPhone(''); setSendEmail('') }}>
+        <Dialog open onClose={resetSendDialog}>
           <div className="sticky top-0 bg-card border-b px-4 py-3 flex items-center justify-between rounded-t-xl z-10">
-            <DialogTitle className="mb-0 text-sm">Enviar ficha ao cliente</DialogTitle>
+            <DialogTitle className="mb-0 text-sm">O que fazer com a ficha?</DialogTitle>
+            <span className="text-[10px] text-muted-foreground">Etapa 2 de 2</span>
           </div>
-          <div className="p-4 space-y-3">
-            <p className="text-xs text-muted-foreground">
-              Gere um link seguro e envie ao cliente via WhatsApp ou e-mail.
+          <div className="p-4 space-y-5">
+            <p className="text-sm text-muted-foreground">
+              Paciente: <strong>{customerName}</strong>
             </p>
-            <div className="space-y-1">
-              <label className="text-xs font-medium text-muted-foreground">WhatsApp (opcional)</label>
-              <input
-                type="tel"
-                value={sendPhone}
-                onChange={(e) => setSendPhone(e.target.value)}
-                placeholder="+55 11 99999-9999"
-                className="w-full rounded-md border bg-background px-2 py-1.5 text-xs"
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs font-medium text-muted-foreground">E-mail (opcional)</label>
-              <input
-                type="email"
-                value={sendEmail}
-                onChange={(e) => setSendEmail(e.target.value)}
-                placeholder="cliente@email.com"
-                className="w-full rounded-md border bg-background px-2 py-1.5 text-xs"
-              />
+            <div className="space-y-3">
+              {/* Enviar ao cliente agora */}
+              <label className="flex items-start gap-3 rounded-lg border p-3 cursor-pointer has-[:checked]:border-primary has-[:checked]:bg-primary/5 transition-colors">
+                <input
+                  type="radio"
+                  name="tab-dispatch-mode"
+                  value="send"
+                  checked={dispatchMode === 'send'}
+                  onChange={() => setDispatchMode('send')}
+                  className="mt-0.5 shrink-0"
+                />
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">Enviar ao cliente agora</p>
+                  <p className="text-xs text-muted-foreground">Gera um link seguro e notifica via WhatsApp ou e-mail.</p>
+                </div>
+              </label>
+
+              {dispatchMode === 'send' && (
+                <div className="ml-6 space-y-3 rounded-lg border p-4">
+                  <p className="text-xs font-medium text-muted-foreground">Enviar por</p>
+
+                  {/* WhatsApp */}
+                  <div className="flex items-center gap-3">
+                    <Checkbox
+                      id="tab-dispatch-whatsapp"
+                      checked={sendViaWhatsapp}
+                      onCheckedChange={(v) => setSendViaWhatsapp(Boolean(v))}
+                    />
+                    <label htmlFor="tab-dispatch-whatsapp" className="flex items-center gap-2 cursor-pointer select-none">
+                      <MessageCircle className="h-4 w-4 text-green-600 shrink-0" />
+                      <span className="text-sm font-medium">WhatsApp</span>
+                    </label>
+                  </div>
+                  {sendViaWhatsapp && (
+                    <div className="ml-7 space-y-1.5">
+                      <PhoneInput id="tab-dispatch-phone" value={sendPhone} onChange={handleSendPhoneChange} />
+                      {sendPhoneError && <p className="text-xs text-red-500">{sendPhoneError}</p>}
+                    </div>
+                  )}
+
+                  {/* E-mail */}
+                  <div className="flex items-center gap-3">
+                    <Checkbox
+                      id="tab-dispatch-email"
+                      checked={sendViaEmail}
+                      onCheckedChange={(v) => setSendViaEmail(Boolean(v))}
+                    />
+                    <label htmlFor="tab-dispatch-email" className="flex items-center gap-2 cursor-pointer select-none">
+                      <Mail className="h-4 w-4 text-violet-600 shrink-0" />
+                      <span className="text-sm font-medium">E-mail</span>
+                    </label>
+                  </div>
+                  {sendViaEmail && (
+                    <div className="ml-7 space-y-1.5">
+                      <Label htmlFor="tab-dispatch-email-input">E-mail do cliente</Label>
+                      <Input
+                        id="tab-dispatch-email-input"
+                        type="email"
+                        placeholder="cliente@exemplo.com"
+                        value={sendEmail}
+                        onChange={(e) => setSendEmail(e.target.value)}
+                        className="h-9 text-sm"
+                      />
+                    </div>
+                  )}
+
+                  {!sendViaWhatsapp && !sendViaEmail && (
+                    <p className="text-xs text-red-500">Selecione ao menos um canal de envio.</p>
+                  )}
+
+                  <p className="text-xs text-muted-foreground pt-1">
+                    O link expira em 7 dias. Você pode reenviar depois se necessário.
+                  </p>
+                </div>
+              )}
+
+              {/* Salvar para enviar depois */}
+              <label
+                className={[
+                  'flex items-start gap-3 rounded-lg border p-3 transition-colors',
+                  sendingMode === 'blank'
+                    ? 'cursor-not-allowed opacity-50'
+                    : 'cursor-pointer has-[:checked]:border-primary has-[:checked]:bg-primary/5',
+                ].join(' ')}
+              >
+                <input
+                  type="radio"
+                  name="tab-dispatch-mode"
+                  value="save"
+                  checked={dispatchMode === 'save'}
+                  onChange={() => setDispatchMode('save')}
+                  disabled={sendingMode === 'blank'}
+                  className="mt-0.5 shrink-0"
+                />
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">Salvar para enviar depois</p>
+                  <p className="text-xs text-muted-foreground">
+                    {sendingMode === 'blank'
+                      ? 'Disponível apenas no modo pré-preenchido.'
+                      : 'Mantém a ficha salva com status "Preenchida pela clínica".'}
+                  </p>
+                </div>
+              </label>
             </div>
           </div>
           <div className="sticky bottom-0 bg-card border-t px-4 py-3 flex justify-end gap-2 rounded-b-xl">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => { setSendingId(null); setSendPhone(''); setSendEmail('') }}
-            >
+            <Button type="button" variant="outline" size="sm" onClick={resetSendDialog}>
               Cancelar
             </Button>
-            <Button
-              type="button"
-              size="sm"
-              onClick={() => void handleSend(sendingId)}
-              disabled={sendAnamnesis.isPending}
-            >
-              {sendAnamnesis.isPending && <Loader2 className="h-3 w-3 animate-spin" />}
-              Enviar
-            </Button>
+            {dispatchMode === 'send' ? (
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => void handleSend(sendingId)}
+                disabled={sendAnamnesis.isPending || !canSendNow}
+              >
+                {sendAnamnesis.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                ) : (
+                  <Send className="h-3.5 w-3.5 mr-1.5" />
+                )}
+                Enviar ao cliente
+              </Button>
+            ) : (
+              <Button type="button" size="sm" onClick={() => { resetSendDialog(); toast.success('Ficha salva. Envie ao cliente quando quiser.') }}>
+                <Save className="h-3.5 w-3.5 mr-1.5" />
+                Salvar ficha
+              </Button>
+            )}
           </div>
         </Dialog>
       )}

--- a/aesthera/apps/web/lib/status-colors.ts
+++ b/aesthera/apps/web/lib/status-colors.ts
@@ -12,24 +12,24 @@ export const ANAMNESIS_STATUS_LABEL: Record<string, string> = {
 
 /** @deprecated Use ANAMNESIS_STATUS_COLORS */
 export const ANAMNESIS_STATUS_COLOR: Record<string, string> = {
-  draft: 'bg-slate-100 text-slate-700 dark:bg-slate-900/40 dark:text-slate-300',
-  clinic_filled: 'bg-teal-100 text-teal-800 dark:bg-teal-900/40 dark:text-teal-300',
-  sent_to_client: 'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-300',
-  client_submitted: 'bg-violet-100 text-violet-800 dark:bg-violet-900/40 dark:text-violet-300',
-  pending: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
-  signed: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
-  expired: 'bg-muted text-muted-foreground',
-  correction_requested: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
-  cancelled: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400',
+  draft:                'bg-slate-500 text-white dark:bg-slate-600',
+  clinic_filled:        'bg-teal-600 text-white dark:bg-teal-700',
+  sent_to_client:       'bg-indigo-600 text-white dark:bg-indigo-700',
+  client_submitted:     'bg-amber-700 text-white dark:bg-amber-800',
+  pending:              'bg-slate-500 text-white dark:bg-slate-600',
+  signed:               'bg-emerald-600 text-white dark:bg-emerald-700',
+  expired:              'bg-slate-500 text-white dark:bg-slate-600',
+  correction_requested: 'bg-orange-700 text-white dark:bg-orange-800',
+  cancelled:            'bg-rose-600 text-white dark:bg-rose-700',
 }
 
 /** Constante canônica para cores de status de anamnese */
 export const ANAMNESIS_STATUS_COLORS = ANAMNESIS_STATUS_COLOR
 
 export const PROMOTION_STATUS_COLOR: Record<string, string> = {
-  active: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
-  inactive: 'bg-muted text-muted-foreground dark:bg-muted dark:text-muted-foreground',
-  expired: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  active:   'bg-emerald-600 text-white dark:bg-emerald-700',
+  inactive: 'bg-slate-500 text-white dark:bg-slate-600',
+  expired:  'bg-rose-600 text-white dark:bg-rose-700',
 }
 
 export const BILLING_SOURCE_TYPE_LABEL: Record<string, string> = {
@@ -42,12 +42,12 @@ export const BILLING_SOURCE_TYPE_LABEL: Record<string, string> = {
 }
 
 export const BILLING_SOURCE_TYPE_COLOR: Record<string, string> = {
-  APPOINTMENT:     'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
-  PRESALE:         'bg-violet-100 text-violet-800 dark:bg-violet-900/40 dark:text-violet-200',
-  MANUAL:          'bg-muted text-muted-foreground',
-  PACKAGE_SALE:    'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
-  PRODUCT_SALE:    'bg-teal-100 text-teal-800 dark:bg-teal-900/40 dark:text-teal-200',
-  WALLET_PURCHASE: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
+  APPOINTMENT:     'bg-blue-600 text-white dark:bg-blue-700',
+  PRESALE:         'bg-violet-600 text-white dark:bg-violet-700',
+  MANUAL:          'bg-slate-500 text-white dark:bg-slate-600',
+  PACKAGE_SALE:    'bg-amber-700 text-white dark:bg-amber-800',
+  PRODUCT_SALE:    'bg-teal-600 text-white dark:bg-teal-700',
+  WALLET_PURCHASE: 'bg-emerald-600 text-white dark:bg-emerald-700',
 }
 
 export const BILLING_STATUS_LABEL: Record<string, string> = {
@@ -58,10 +58,10 @@ export const BILLING_STATUS_LABEL: Record<string, string> = {
 }
 
 export const BILLING_STATUS_COLOR: Record<string, string> = {
-  pending:   'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200',
-  paid:      'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
-  overdue:   'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
-  cancelled: 'bg-muted text-muted-foreground',
+  pending:   'bg-amber-700 text-white dark:bg-amber-800',
+  paid:      'bg-emerald-600 text-white dark:bg-emerald-700',
+  overdue:   'bg-rose-600 text-white dark:bg-rose-700',
+  cancelled: 'bg-slate-500 text-white dark:bg-slate-600',
 }
 
 export const SESSION_STATUS_STYLE: Record<string, string> = {
@@ -89,10 +89,10 @@ export const PAYMENT_METHOD_LABELS: Record<string, string> = {
 }
 
 export const PAYMENT_METHOD_BADGE_COLORS: Record<string, string> = {
-  cash:           'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
-  pix:            'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200',
-  card:           'bg-violet-100 text-violet-800 dark:bg-violet-900/40 dark:text-violet-200',
-  transfer:       'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
-  wallet_credit:  'bg-amber-200 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200',
-  wallet_voucher: 'bg-orange-200 text-orange-900 dark:bg-orange-900/40 dark:text-orange-200',
+  cash:           'bg-emerald-600 text-white dark:bg-emerald-700',
+  pix:            'bg-sky-600 text-white dark:bg-sky-700',
+  card:           'bg-violet-600 text-white dark:bg-violet-700',
+  transfer:       'bg-blue-600 text-white dark:bg-blue-700',
+  wallet_credit:  'bg-amber-700 text-white dark:bg-amber-800',
+  wallet_voucher: 'bg-orange-700 text-white dark:bg-orange-800',
 }


### PR DESCRIPTION
## Contexto

Padrão de badge de status atualizado em 09/04/2026 após aprovação do produto (baseado na tela de anamneses). O padrão pastel (fundo `-100`/`-200` + texto escuro) foi **banido** e substituído pelo padrão sólido (fundo saturado + `text-white`).

Um gate de compliance foi adicionado ao pre-commit hook (GATE 3) que bloqueia commits com shades `-100` ou `-200` em `lib/status-colors.ts`. Esta migração é necessária para desbloquear commits.

**Referências:**
- `ai-engineering/prompts/aesthera-implementador/patterns/frontend-cores-status.md` — item 🔴 BLOQUEANTE
- `aesthera/docs/ui-standards.md` — seção 6 (Status Badges)

---

## O que foi feito

Migração das 5 constantes de cor em `apps/web/lib/status-colors.ts`:

| Constante | Antes | Depois |
|---|---|---|
| `ANAMNESIS_STATUS_COLOR` | pastel (`-100`, `-200`, `text-*-900`) | sólido (`-600`/`-700`, `text-white`) |
| `PROMOTION_STATUS_COLOR` | pastel (`-100`, `text-*-800`) | sólido (`-600`, `text-white`) |
| `BILLING_STATUS_COLOR` | pastel (`-100`, `text-*-800`) | sólido (`-600`/`-700`, `text-white`) |
| `BILLING_SOURCE_TYPE_COLOR` | pastel (`-100`, `text-*-800`) | sólido (`-600`/`-700`, `text-white`) |
| `PAYMENT_METHOD_BADGE_COLORS` | pastel (`-100`/`-200`, `text-*-800`) | sólido (`-600`/`-700`, `text-white`) |

**Regra WCAG aplicada** — shade mínima para `text-white` com contraste ≥ 4.5:1:
- emerald, teal, green, rose, red, indigo, violet → **-600**
- amber, orange, yellow → **-700**
- slate, zinc, gray → **-500**

---

## Escopo

Apenas `apps/web/lib/status-colors.ts`. Nenhum componente alterado — todos importam as constantes dessa fonte canônica.

---

## Critérios de aceite

- [x] Nenhuma shade `-100` ou `-200` em `lib/status-colors.ts`
- [x] Todas as entradas usam `text-white`
- [x] Shades respeitam o mínimo WCAG por paleta
- [x] Pre-commit hook GATE 3 passa sem erro