### PR TITLE
feat(#159): aba Avaliações no perfil do cliente e fichas personalizadas

### DIFF
--- a/aesthera/apps/api/src/modules/measurement-sessions/measurement-sessions.dto.ts
+++ b/aesthera/apps/api/src/modules/measurement-sessions/measurement-sessions.dto.ts
@@ -54,5 +54,6 @@ export const ListSessionsQuery = z.object({
   customerId: z.string().uuid(),
   page: z.coerce.number().int().positive().default(1),
   limit: z.coerce.number().int().positive().max(100).default(20),
+  category: z.enum(['CORPORAL', 'FACIAL', 'DERMATO_FUNCIONAL', 'NUTRICIONAL', 'POSTURAL', 'PERSONALIZADA']).optional(),
 })
 export type ListSessionsQuery = z.infer<typeof ListSessionsQuery>

--- a/aesthera/apps/api/src/modules/measurement-sessions/measurement-sessions.repository.ts
+++ b/aesthera/apps/api/src/modules/measurement-sessions/measurement-sessions.repository.ts
@@ -34,16 +34,19 @@ const SESSION_INCLUDE = {
 export class MeasurementSessionsRepository {
   async listSessions(clinicId: string, q: ListSessionsQuery) {
     const skip = (q.page - 1) * q.limit
+    const categoryFilter = q.category
+      ? { sheetRecords: { some: { sheet: { category: q.category } } } }
+      : {}
     const [items, total] = await Promise.all([
       prisma.measurementSession.findMany({
-        where: { clinicId, customerId: q.customerId },
+        where: { clinicId, customerId: q.customerId, ...categoryFilter },
         orderBy: { recordedAt: 'desc' },
         skip,
         take: q.limit,
         include: SESSION_INCLUDE,
       }),
       prisma.measurementSession.count({
-        where: { clinicId, customerId: q.customerId },
+        where: { clinicId, customerId: q.customerId, ...categoryFilter },
       }),
     ])
     return { items, total, page: q.page, limit: q.limit }

--- a/aesthera/apps/api/src/modules/measurement-sheets/measurement-sheets.dto.ts
+++ b/aesthera/apps/api/src/modules/measurement-sheets/measurement-sheets.dto.ts
@@ -9,6 +9,7 @@ export const CreateSheetDto = z.object({
   category: z.enum(['CORPORAL', 'FACIAL', 'DERMATO_FUNCIONAL', 'NUTRICIONAL', 'POSTURAL', 'PERSONALIZADA']).default('CORPORAL'),
   scope: z.enum(['SYSTEM', 'CUSTOMER']).default('SYSTEM'),
   customerId: z.string().uuid().optional(),
+  sourceSheetId: z.string().uuid().optional(),
 }).refine(
   (data) => data.scope !== 'CUSTOMER' || !!data.customerId,
   { message: 'customerId é obrigatório quando scope=CUSTOMER', path: ['customerId'] },

--- a/aesthera/apps/api/src/modules/measurement-sheets/measurement-sheets.repository.ts
+++ b/aesthera/apps/api/src/modules/measurement-sheets/measurement-sheets.repository.ts
@@ -42,7 +42,13 @@ export class MeasurementSheetsRepository {
   }
 
   async findSheetById(id: string, clinicId: string) {
-    return prisma.measurementSheet.findFirst({ where: { id, clinicId } })
+    return prisma.measurementSheet.findFirst({
+      where: { id, clinicId },
+      include: {
+        columns: { orderBy: { order: 'asc' } },
+        fields: { orderBy: { order: 'asc' } },
+      },
+    })
   }
 
   async findSheetByName(clinicId: string, name: string) {

--- a/aesthera/apps/api/src/modules/measurement-sheets/measurement-sheets.service.ts
+++ b/aesthera/apps/api/src/modules/measurement-sheets/measurement-sheets.service.ts
@@ -16,7 +16,7 @@ import {
 } from './measurement-sheets.dto'
 import { MeasurementSheetsRepository } from './measurement-sheets.repository'
 import { AppointmentsRepository } from '../appointments/appointments.repository'
-import { MEASUREMENT_TEMPLATES } from './measurement-templates'
+import { MEASUREMENT_TEMPLATES, resolveSimpleField, resolveTabularColumn, resolveTabularRow } from './measurement-templates'
 import { prisma as defaultPrisma } from '../../database/prisma/client'
 import type { PrismaClient } from '@prisma/client'
 import { MeasurementCategory, MeasurementScope, MeasurementSheetType } from '@prisma/client'
@@ -253,16 +253,22 @@ export class MeasurementSheetsService {
             order: 0,
           },
         })
-        const fields = (template as { fields: string[] }).fields
+        const fields = (template as { fields: unknown[] }).fields
         await tx.measurementField.createMany({
-          data: fields.map((fieldName, idx) => ({
-            sheetId: sheet.id,
-            clinicId,
-            name: fieldName,
-            inputType: 'INPUT',
-            order: idx,
-            active: true,
-          })),
+          data: fields.map((f, idx) => {
+            const r = resolveSimpleField(f as Parameters<typeof resolveSimpleField>[0])
+            return {
+              sheetId: sheet.id,
+              clinicId,
+              name: r.name,
+              inputType: r.inputType,
+              isTextual: r.isTextual,
+              unit: r.unit ?? undefined,
+              subColumns: r.subColumns,
+              order: idx,
+              active: true,
+            }
+          }),
         })
         return tx.measurementSheet.findFirst({
           where: { id: sheet.id },
@@ -282,24 +288,33 @@ export class MeasurementSheetsService {
             order: 0,
           },
         })
-        const tpl = template as { rows: string[]; columns: string[] }
+        const tpl = template as { rows: unknown[]; columns: unknown[] }
         await tx.measurementField.createMany({
-          data: tpl.rows.map((rowName, idx) => ({
-            sheetId: sheet.id,
-            clinicId,
-            name: rowName,
-            inputType: 'INPUT',
-            order: idx,
-            active: true,
-          })),
+          data: tpl.rows.map((r, idx) => {
+            const row = resolveTabularRow(r as Parameters<typeof resolveTabularRow>[0])
+            return {
+              sheetId: sheet.id,
+              clinicId,
+              name: row.name,
+              inputType: 'INPUT' as const,
+              defaultValue: row.defaultValue ?? undefined,
+              order: idx,
+              active: true,
+            }
+          }),
         })
         await tx.measurementSheetColumn.createMany({
-          data: tpl.columns.map((colName, idx) => ({
-            sheetId: sheet.id,
-            name: colName,
-            inputType: 'INPUT',
-            order: idx,
-          })),
+          data: tpl.columns.map((c, idx) => {
+            const col = resolveTabularColumn(c as Parameters<typeof resolveTabularColumn>[0])
+            return {
+              sheetId: sheet.id,
+              name: col.name,
+              inputType: col.inputType,
+              isTextual: col.isTextual,
+              defaultValue: col.defaultValue ?? undefined,
+              order: idx,
+            }
+          }),
         })
         return tx.measurementSheet.findFirst({
           where: { id: sheet.id },

--- a/aesthera/apps/api/src/modules/measurement-sheets/measurement-sheets.service.ts
+++ b/aesthera/apps/api/src/modules/measurement-sheets/measurement-sheets.service.ts
@@ -77,6 +77,69 @@ export class MeasurementSheetsService {
       throw new ConflictError('Nome de ficha já existe nesta clínica')
     }
 
+    // Se sourceSheetId fornecido: clonar campos e colunas da ficha de origem
+    if (dto.sourceSheetId) {
+      const sourceSheet = await this.repo.findSheetById(dto.sourceSheetId, clinicId)
+      if (!sourceSheet) throw new NotFoundError('MeasurementSheet')
+
+      return this.db.$transaction(async (tx) => {
+        const newSheet = await tx.measurementSheet.create({
+          data: {
+            clinicId,
+            name: dto.name,
+            type: sourceSheet.type,
+            category: dto.category ?? sourceSheet.category,
+            scope: scope as 'SYSTEM' | 'CUSTOMER',
+            customerId: dto.customerId ?? null,
+            createdByUserId: userId ?? null,
+            order: 0,
+          },
+        })
+
+        // Clonar colunas (fichas TABULAR)
+        if (sourceSheet.columns && sourceSheet.columns.length > 0) {
+          await tx.measurementSheetColumn.createMany({
+            data: sourceSheet.columns.map((col) => ({
+              sheetId: newSheet.id,
+              name: col.name,
+              inputType: col.inputType,
+              unit: col.unit ?? null,
+              isTextual: col.isTextual,
+              defaultValue: col.defaultValue ?? null,
+              order: col.order,
+            })),
+          })
+        }
+
+        // Clonar campos/linhas
+        const activeFields = sourceSheet.fields.filter((f) => f.active)
+        if (activeFields.length > 0) {
+          await tx.measurementField.createMany({
+            data: activeFields.map((field) => ({
+              sheetId: newSheet.id,
+              clinicId,
+              name: field.name,
+              inputType: field.inputType,
+              unit: field.unit ?? null,
+              isTextual: field.isTextual,
+              defaultValue: field.defaultValue ?? null,
+              subColumns: field.subColumns ?? [],
+              order: field.order,
+              active: true,
+            })),
+          })
+        }
+
+        return tx.measurementSheet.findFirst({
+          where: { id: newSheet.id },
+          include: {
+            columns: { orderBy: { order: 'asc' } },
+            fields: { orderBy: { order: 'asc' } },
+          },
+        })
+      })
+    }
+
     return this.repo.createSheet(clinicId, dto, userId)
   }
   async updateSheet(id: string, clinicId: string, dto: UpdateSheetDto, userId?: string, role?: string) {

--- a/aesthera/apps/api/src/modules/measurement-sheets/measurement-sheets.test.ts
+++ b/aesthera/apps/api/src/modules/measurement-sheets/measurement-sheets.test.ts
@@ -513,4 +513,110 @@ describe('MeasurementSheetsService', () => {
       expect(result.data.customerId).toBeUndefined()
     }
   })
+
+  // ─── createSheet: sourceSheetId (deep clone) ──────────────────────────────
+
+  it('[#159] POST com sourceSheetId válido → clona campos e colunas da ficha de origem', async () => {
+    const SOURCE_SHEET_ID = 'source-sheet-1'
+    const sourceSheet = makeSheet({
+      id: SOURCE_SHEET_ID,
+      type: 'TABULAR',
+      columns: [makeColumn()],
+      fields: [makeField({ active: true, isTextual: false, subColumns: [], defaultValue: null })],
+    })
+
+    vi.mocked(repo.countActiveSheets).mockResolvedValue(0)
+    vi.mocked(repo.existsSheetNameInClinic).mockResolvedValue(false)
+
+    const txMock = {
+      measurementSheet: {
+        create: vi.fn().mockResolvedValue({ id: 'new-sheet', clinicId: CLINIC_ID, type: 'TABULAR' }),
+        findFirst: vi.fn().mockResolvedValue({ id: 'new-sheet', clinicId: CLINIC_ID, columns: [makeColumn()], fields: [makeField()] }),
+      },
+      measurementSheetColumn: { createMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      measurementField: { createMany: vi.fn().mockResolvedValue({ count: 1 }) },
+    }
+
+    const dbMock = {
+      customer: { findFirst: vi.fn().mockResolvedValue({ id: 'customer-1', clinicId: CLINIC_ID }) },
+      $transaction: vi.fn().mockImplementation(async (fn: (tx: any) => Promise<any>) => fn(txMock)),
+    }
+
+    ;(svc as any).db = dbMock
+    vi.mocked(repo.findSheetById).mockResolvedValue(sourceSheet as any)
+
+    await svc.createSheet(
+      CLINIC_ID,
+      {
+        name: 'Perimetria (João)',
+        type: 'TABULAR',
+        category: 'PERSONALIZADA',
+        scope: 'CUSTOMER',
+        customerId: 'customer-1',
+        sourceSheetId: SOURCE_SHEET_ID,
+      },
+      'staff-1',
+      'staff',
+    )
+
+    expect(dbMock.$transaction).toHaveBeenCalledOnce()
+    expect(txMock.measurementSheetColumn.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([expect.objectContaining({ name: makeColumn().name })]),
+      }),
+    )
+    expect(txMock.measurementField.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([expect.objectContaining({ name: makeField().name })]),
+      }),
+    )
+  })
+
+  it('[#159] POST com sourceSheetId de ficha inexistente → 404', async () => {
+    vi.mocked(repo.countActiveSheets).mockResolvedValue(0)
+    vi.mocked(repo.existsSheetNameInClinic).mockResolvedValue(false)
+    vi.mocked(repo.findSheetById).mockResolvedValue(null)
+
+    const { NotFoundError } = await import('../../shared/errors/app-error')
+
+    ;(svc as any).db = {
+      customer: { findFirst: vi.fn().mockResolvedValue({ id: 'customer-1', clinicId: CLINIC_ID }) },
+    }
+
+    await expect(
+      svc.createSheet(
+        CLINIC_ID,
+        {
+          name: 'Cópia',
+          type: 'SIMPLE',
+          category: 'PERSONALIZADA',
+          scope: 'CUSTOMER',
+          customerId: 'customer-1',
+          sourceSheetId: 'nao-existe',
+        },
+        'staff-1',
+        'staff',
+      ),
+    ).rejects.toThrow(NotFoundError)
+  })
+
+  it('[#159] POST sem sourceSheetId → chama repo.createSheet (sem clone)', async () => {
+    vi.mocked(repo.countActiveSheets).mockResolvedValue(0)
+    vi.mocked(repo.existsSheetNameInClinic).mockResolvedValue(false)
+    vi.mocked(repo.createSheet).mockResolvedValue(makeSheet({ scope: 'CUSTOMER' }) as any)
+
+    ;(svc as any).db = {
+      customer: { findFirst: vi.fn().mockResolvedValue({ id: 'customer-1', clinicId: CLINIC_ID }) },
+    }
+
+    await svc.createSheet(
+      CLINIC_ID,
+      { name: 'Em Branco', type: 'SIMPLE', category: 'PERSONALIZADA', scope: 'CUSTOMER', customerId: 'customer-1' },
+      'staff-1',
+      'staff',
+    )
+
+    expect(repo.createSheet).toHaveBeenCalledOnce()
+  })
 })
+

--- a/aesthera/apps/api/src/modules/measurement-sheets/measurement-templates.ts
+++ b/aesthera/apps/api/src/modules/measurement-sheets/measurement-templates.ts
@@ -1,11 +1,38 @@
 import { MeasurementCategory, MeasurementSheetType } from '@prisma/client'
 
+// ─── Field / column descriptors ─────────────────────────────────────────────
+
+export type SimpleTemplateField =
+  | string
+  | {
+      name: string
+      inputType?: 'INPUT' | 'CHECK'
+      isTextual?: boolean
+      unit?: string
+      subColumns?: string[]
+    }
+
+export type TabularTemplateRow =
+  | string
+  | { name: string; defaultValue?: string }
+
+export type TabularTemplateColumn =
+  | string
+  | {
+      name: string
+      inputType?: 'INPUT' | 'CHECK'
+      isTextual?: boolean
+      defaultValue?: string
+    }
+
+// ─── Template shapes ─────────────────────────────────────────────────────────
+
 type SimpleTemplate = {
   id: string
   name: string
   category: MeasurementCategory
   type: typeof MeasurementSheetType.SIMPLE
-  fields: string[]
+  fields: SimpleTemplateField[]
 }
 
 type TabularTemplate = {
@@ -13,19 +40,115 @@ type TabularTemplate = {
   name: string
   category: MeasurementCategory
   type: typeof MeasurementSheetType.TABULAR
-  rows: string[]
-  columns: string[]
+  rows: TabularTemplateRow[]
+  columns: TabularTemplateColumn[]
 }
 
 export type MeasurementTemplate = SimpleTemplate | TabularTemplate
 
+// ─── Normalisers (used by the service) ───────────────────────────────────────
+
+export function resolveSimpleField(f: SimpleTemplateField) {
+  const obj = typeof f === 'string' ? { name: f } : f
+  return {
+    name: obj.name,
+    inputType: (obj.inputType ?? 'INPUT') as 'INPUT' | 'CHECK',
+    isTextual: obj.isTextual ?? false,
+    unit: obj.unit ?? null,
+    subColumns: obj.subColumns ?? [],
+  }
+}
+
+export function resolveTabularRow(r: TabularTemplateRow) {
+  if (typeof r === 'string') return { name: r, defaultValue: null }
+  return { name: r.name, defaultValue: r.defaultValue ?? null }
+}
+
+export function resolveTabularColumn(c: TabularTemplateColumn) {
+  const obj = typeof c === 'string' ? { name: c } : c
+  return {
+    name: obj.name,
+    inputType: (obj.inputType ?? 'INPUT') as 'INPUT' | 'CHECK',
+    isTextual: obj.isTextual ?? false,
+    defaultValue: obj.defaultValue ?? null,
+  }
+}
+
+// ─── Templates ───────────────────────────────────────────────────────────────
+
 export const MEASUREMENT_TEMPLATES: MeasurementTemplate[] = [
+
+  // ── Corporal ────────────────────────────────────────────────────────────────
+  {
+    id: 'tpl-composicao-corporal',
+    name: 'Composição Corporal',
+    category: MeasurementCategory.CORPORAL,
+    type: MeasurementSheetType.SIMPLE,
+    fields: ['Peso', '% Gordura', '% Músculo', '% Água', '% Osso', 'Altura', 'IMC'],
+  },
+  {
+    id: 'tpl-avaliacao-corporal-estetica',
+    name: 'Avaliação Corporal Estética',
+    category: MeasurementCategory.CORPORAL,
+    type: MeasurementSheetType.TABULAR,
+    rows: ['Braços', 'Costas', 'Axilares', 'Flancos', 'Abdome', 'Glúteos', 'Culotes', 'Anterior Coxas'],
+    columns: [
+      { name: 'FEG I',                       inputType: 'CHECK' },
+      { name: 'FEG II',                      inputType: 'CHECK' },
+      { name: 'FEG III',                     inputType: 'CHECK' },
+      { name: 'Adiposidade',                 inputType: 'CHECK' },
+      { name: 'Dura/Mole',                   inputType: 'CHECK' },
+      { name: 'Flacidez Muscular/Tissular',  inputType: 'CHECK' },
+      { name: 'Estrias (Brancas/Vermelhas)', inputType: 'CHECK' },
+      { name: 'Varicose',                    inputType: 'CHECK' },
+    ],
+  },
   {
     id: 'tpl-perimetria',
     name: 'Perimetria',
     category: MeasurementCategory.CORPORAL,
+    type: MeasurementSheetType.TABULAR,
+    columns: [
+      { name: 'Posição',     inputType: 'INPUT', isTextual: true  },
+      { name: 'Medida (cm)', inputType: 'INPUT', isTextual: false },
+    ],
+    rows: [
+      { name: 'Abdome 1', defaultValue: '00 cm acima umbigo' },
+      { name: 'Abdome 2', defaultValue: '00 cm acima umbigo' },
+      { name: 'Abdome 3', defaultValue: '00 cm acima umbigo' },
+      { name: 'Abdome 4', defaultValue: '00 cm acima umbigo' },
+      { name: 'Abdome 5', defaultValue: '00 cm abaixo umbigo' },
+      { name: 'Abdome 6', defaultValue: '00 cm abaixo umbigo' },
+      { name: 'Abdome 7', defaultValue: '00 cm abaixo umbigo' },
+      { name: 'Abdome 8', defaultValue: '00 cm abaixo umbigo' },
+      'Umbigo',
+      'Cintura',
+      'Quadril',
+      'Tórax',
+      'Braço Relaxado D',
+      'Braço Relaxado E',
+      'Braço Contraído D',
+      'Braço Contraído E',
+      'Antebraço D',
+      'Antebraço E',
+      { name: 'Coxa 1 D', defaultValue: '00 cm abaixo EIAS' },
+      { name: 'Coxa 1 E', defaultValue: '00 cm abaixo EIAS' },
+      { name: 'Coxa 2 D', defaultValue: '00 cm abaixo EIAS' },
+      { name: 'Coxa 2 E', defaultValue: '00 cm abaixo EIAS' },
+      'Joelho D',
+      'Joelho E',
+      { name: 'Braço 1 D', defaultValue: '00 cm abaixo acrômio' },
+      { name: 'Braço 1 E', defaultValue: '00 cm abaixo acrômio' },
+      { name: 'Braço 2 D', defaultValue: '00 cm abaixo acrômio' },
+      { name: 'Braço 2 E', defaultValue: '00 cm abaixo acrômio' },
+    ],
+  },
+  {
+    id: 'tpl-plicometria',
+    name: 'Plicometria',
+    category: MeasurementCategory.CORPORAL,
     type: MeasurementSheetType.SIMPLE,
-    fields: ['Cintura', 'Abdome', 'Quadril', 'Braço D', 'Braço E', 'Coxa D', 'Coxa E'],
+    fields: ['Tríceps', 'Subescapular', 'Bíceps', 'Axilar média', 'Supra-ilíaca', 'Peitoral', 'Abdominal'],
   },
   {
     id: 'tpl-bioimpedancia',
@@ -34,6 +157,8 @@ export const MEASUREMENT_TEMPLATES: MeasurementTemplate[] = [
     type: MeasurementSheetType.SIMPLE,
     fields: ['Peso', 'Altura', '% Gordura', 'Massa Muscular', 'Massa Óssea', 'Água Corporal'],
   },
+
+  // ── Dermato-funcional ───────────────────────────────────────────────────────
   {
     id: 'tpl-condicao-estetica',
     name: 'Condição Estética',
@@ -50,6 +175,8 @@ export const MEASUREMENT_TEMPLATES: MeasurementTemplate[] = [
     rows: ['Braços', 'Abdome', 'Flancos', 'Glúteos', 'Coxas'],
     columns: ['Grau 1', 'Grau 2', 'Grau 3', 'Grau 4'],
   },
+
+  // ── Facial ───────────────────────────────────────────────────────────────────
   {
     id: 'tpl-avaliacao-facial',
     name: 'Avaliação Facial',
@@ -57,6 +184,8 @@ export const MEASUREMENT_TEMPLATES: MeasurementTemplate[] = [
     type: MeasurementSheetType.SIMPLE,
     fields: ['Fototipo Fitzpatrick', 'Tipo de Pele', 'Oleosidade', 'Sensibilidade', 'Manchas', 'Rugas'],
   },
+
+  // ── Postural ─────────────────────────────────────────────────────────────────
   {
     id: 'tpl-postural',
     name: 'Avaliação Postural',

--- a/aesthera/apps/web/app/(dashboard)/customers/page.tsx
+++ b/aesthera/apps/web/app/(dashboard)/customers/page.tsx
@@ -2267,7 +2267,7 @@ function CustomerDetail({ customer, onEdit, onClose }: { customer: Customer; onE
 
       {/* Detail tabs */}
       <div className="flex rounded-lg border overflow-hidden">
-        {([['profile', 'Dados'], ['history', 'Histórico'], ['wallet', 'Carteira'], ['prontuario', 'Prontuário'], ['anamnese', 'Anamnese'], ['contracts', 'Contratos'], ['evolucao', 'Avaliação']] as const).map(([id, label]) => (
+        {([['profile', 'Dados'], ['history', 'Histórico'], ['wallet', 'Carteira'], ['prontuario', 'Prontuário'], ['anamnese', 'Anamnese'], ['contracts', 'Contratos'], ['evolucao', 'Avaliações']] as const).map(([id, label]) => (
           <button
             key={id}
             type="button"

--- a/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
+++ b/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
@@ -1300,7 +1300,7 @@ export function MeasurementSheetsSettings() {
           </div>
         </div>
 
-        <div className="hidden xl:block w-[400px] shrink-0">
+        <div className="hidden xl:block w-[500px] shrink-0">
           {selectedSheet ? (
             <SheetEditorPanel sheet={selectedSheet} isReadonly={isPersonalizada} onDeleted={() => setSelectedSheetId(null)} />
           ) : (

--- a/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
+++ b/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
@@ -69,12 +69,60 @@ import {
   MEASUREMENT_CATEGORIES_ORDER,
   CATEGORY_ICON,
   SHEET_TYPE_BADGE_COLOR,
-  FIELD_INPUT_TYPE_BADGE_COLOR,
+  FIELD_DISPLAY_TYPE_LABEL,
+  FIELD_DISPLAY_TYPE_BADGE_COLOR,
+  type FieldDisplayType,
 } from '@/lib/measurement-categories'
 import { MeasurementTemplatesDrawer } from './measurement-templates-drawer'
 import { cn } from '@/lib/utils'
 
 const MAX_ACTIVE_SHEETS = 20
+
+// ---------------------------------------------------------------------------
+// Helpers de tipo de campo (FieldDisplayType — apenas UI, não persiste no banco)
+// ---------------------------------------------------------------------------
+
+function toDisplayType(inputType: MeasurementInputType, isTextual: boolean): FieldDisplayType {
+  if (inputType === 'CHECK') return 'CHECK'
+  if (isTextual) return 'TEXT'
+  return 'NUMBER'
+}
+
+function fromDisplayType(dt: FieldDisplayType): { inputType: MeasurementInputType; isTextual: boolean } {
+  if (dt === 'CHECK') return { inputType: 'CHECK', isTextual: false }
+  if (dt === 'TEXT')  return { inputType: 'INPUT', isTextual: true }
+  return { inputType: 'INPUT', isTextual: false }
+}
+
+function FieldTypeSelector({
+  value,
+  onChange,
+}: {
+  value: FieldDisplayType
+  onChange: (v: FieldDisplayType) => void
+}) {
+  return (
+    <div className="flex gap-1.5">
+      {(['NUMBER', 'TEXT', 'CHECK'] as FieldDisplayType[]).map((dt) => (
+        <button
+          key={dt}
+          type="button"
+          onClick={() => onChange(dt)}
+          className={cn(
+            'flex-1 rounded border px-2 py-1.5 text-center text-xs transition-colors',
+            value === dt
+              ? 'border-primary bg-primary/5 font-medium text-primary'
+              : 'border-border text-muted-foreground hover:border-primary/40',
+          )}
+        >
+          {FIELD_DISPLAY_TYPE_LABEL[dt]}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 
 function SortableSheetItem({
   sheet,
@@ -271,9 +319,14 @@ export function SimpleSheetEditor({
   const [editingFieldId, setEditingFieldId] = useState<string | null>(null)
   const [editName, setEditName] = useState('')
   const [editUnit, setEditUnit] = useState('')
+  const [editInputType, setEditInputType] = useState<MeasurementInputType>('INPUT')
+  const [editIsTextual, setEditIsTextual] = useState(false)
   const [isAdding, setIsAdding] = useState(false)
   const [newName, setNewName] = useState('')
   const [newInputType, setNewInputType] = useState<MeasurementInputType>('INPUT')
+  const [newIsTextual, setNewIsTextual] = useState(false)
+  const [newUnit, setNewUnit] = useState('')
+  const [newDirEsq, setNewDirEsq] = useState(false)
   const editInputRef = useRef<HTMLInputElement>(null)
   const addInputRef = useRef<HTMLInputElement>(null)
 
@@ -300,18 +353,23 @@ export function SimpleSheetEditor({
     setEditingFieldId(field.id)
     setEditName(field.name)
     setEditUnit(field.unit ?? '')
+    setEditInputType(field.inputType)
+    setEditIsTextual(field.isTextual)
   }
 
   async function confirmEdit(fieldId: string) {
     const field = sheet.fields.find((f) => f.id === fieldId)
     if (!field || !editName.trim()) return
+    const isNumeric = editInputType === 'INPUT' && !editIsTextual
     try {
       await updateField.mutateAsync({
         sheetId: sheet.id,
         fieldId,
         name: editName.trim(),
-        unit:
-          field.inputType === 'INPUT' && !field.isTextual ? editUnit.trim() || undefined : undefined,
+        inputType: editInputType,
+        isTextual: editIsTextual,
+        unit: isNumeric ? editUnit.trim() || undefined : undefined,
+        subColumns: !isNumeric && field.subColumns?.length ? [] : undefined,
       })
       setEditingFieldId(null)
     } catch {
@@ -349,13 +407,21 @@ export function SimpleSheetEditor({
   async function handleAddField(e: React.FormEvent) {
     e.preventDefault()
     if (!newName.trim()) return
+    const isNumeric = newInputType === 'INPUT' && !newIsTextual
     try {
       await createField.mutateAsync({
         name: newName.trim(),
         inputType: newInputType,
+        isTextual: newIsTextual,
+        unit: isNumeric && newUnit.trim() ? newUnit.trim() : undefined,
+        subColumns: isNumeric && newDirEsq ? ['Direito', 'Esquerdo'] : [],
         order: activeFields.length + 1,
       })
       setNewName('')
+      setNewInputType('INPUT')
+      setNewIsTextual(false)
+      setNewUnit('')
+      setNewDirEsq(false)
       setIsAdding(false)
     } catch {
       toast.error('Erro ao criar campo')
@@ -388,6 +454,8 @@ export function SimpleSheetEditor({
               isEditing={editingFieldId === field.id}
               editName={editName}
               editUnit={editUnit}
+              editInputType={editInputType}
+              editIsTextual={editIsTextual}
               editInputRef={editingFieldId === field.id ? editInputRef : undefined}
               isReadonly={isReadonly}
               onStartEdit={() => startEdit(field)}
@@ -395,6 +463,8 @@ export function SimpleSheetEditor({
               onCancelEdit={cancelEdit}
               onEditNameChange={setEditName}
               onEditUnitChange={setEditUnit}
+              onEditInputTypeChange={(v) => setEditInputType(v)}
+              onEditIsTextualChange={(v) => setEditIsTextual(v)}
               onToggleDirEsq={() => toggleDirEsq(field)}
               onDelete={() => handleDelete(field.id)}
               onMoveUp={
@@ -447,28 +517,34 @@ export function SimpleSheetEditor({
                   }}
                 />
               </div>
-              <div className="flex gap-2">
-                {(['INPUT', 'CHECK'] as MeasurementInputType[]).map((t) => (
-                  <label
-                    key={t}
-                    className={cn(
-                      'flex-1 cursor-pointer rounded border px-2 py-1.5 text-center text-xs transition-colors',
-                      newInputType === t
-                        ? 'border-primary bg-primary/5 font-medium text-primary'
-                        : 'border-border text-muted-foreground hover:border-primary/40',
-                    )}
-                  >
-                    <input
-                      type="radio"
-                      value={t}
-                      checked={newInputType === t}
-                      onChange={() => setNewInputType(t)}
-                      className="sr-only"
-                    />
-                    {t === 'INPUT' ? 'Digitação' : 'Marcação'}
-                  </label>
-                ))}
-              </div>
+              <FieldTypeSelector
+                value={toDisplayType(newInputType, newIsTextual)}
+                onChange={(dt) => {
+                  const { inputType, isTextual } = fromDisplayType(dt)
+                  setNewInputType(inputType)
+                  setNewIsTextual(isTextual)
+                  if (dt !== 'NUMBER') { setNewUnit(''); setNewDirEsq(false) }
+                }}
+              />
+              {newInputType === 'INPUT' && !newIsTextual && (
+                <Input
+                  value={newUnit}
+                  onChange={(e) => setNewUnit(e.target.value)}
+                  placeholder="Unidade (opcional) — ex: cm, kg, %"
+                  className="h-7 text-xs"
+                />
+              )}
+              {newInputType === 'INPUT' && !newIsTextual && (
+                <label className="flex items-center gap-2 text-xs cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={newDirEsq}
+                    onChange={(e) => setNewDirEsq(e.target.checked)}
+                    className="rounded"
+                  />
+                  Dividir em Direito / Esquerdo
+                </label>
+              )}
               <div className="flex gap-2">
                 <Button type="submit" size="sm" className="h-7 text-xs" disabled={!newName.trim() || createField.isPending}>
                   {createField.isPending && <Loader2 className="mr-1 h-3 w-3 animate-spin" />}
@@ -479,7 +555,7 @@ export function SimpleSheetEditor({
                   variant="ghost"
                   size="sm"
                   className="h-7 text-xs"
-                  onClick={() => { setIsAdding(false); setNewName('') }}
+                  onClick={() => { setIsAdding(false); setNewName(''); setNewInputType('INPUT'); setNewIsTextual(false); setNewUnit(''); setNewDirEsq(false) }}
                 >
                   Cancelar
                 </Button>
@@ -511,6 +587,8 @@ function SortableFieldRow({
   isEditing,
   editName,
   editUnit,
+  editInputType,
+  editIsTextual,
   editInputRef,
   isReadonly,
   onStartEdit,
@@ -518,6 +596,8 @@ function SortableFieldRow({
   onCancelEdit,
   onEditNameChange,
   onEditUnitChange,
+  onEditInputTypeChange,
+  onEditIsTextualChange,
   onToggleDirEsq,
   onDelete,
   onMoveUp,
@@ -527,6 +607,8 @@ function SortableFieldRow({
   isEditing: boolean
   editName: string
   editUnit: string
+  editInputType: MeasurementInputType
+  editIsTextual: boolean
   editInputRef?: React.RefObject<HTMLInputElement | null>
   isReadonly: boolean
   onStartEdit: () => void
@@ -534,6 +616,8 @@ function SortableFieldRow({
   onCancelEdit: () => void
   onEditNameChange: (v: string) => void
   onEditUnitChange: (v: string) => void
+  onEditInputTypeChange: (v: MeasurementInputType) => void
+  onEditIsTextualChange: (v: boolean) => void
   onToggleDirEsq: () => void
   onDelete: () => void
   onMoveUp?: () => void
@@ -567,7 +651,16 @@ function SortableFieldRow({
               if (e.key === 'Tab') { e.preventDefault(); onConfirmEdit() }
             }}
           />
-          {isNumericInput && (
+          <FieldTypeSelector
+            value={toDisplayType(editInputType, editIsTextual)}
+            onChange={(dt) => {
+              const { inputType, isTextual } = fromDisplayType(dt)
+              onEditInputTypeChange(inputType)
+              onEditIsTextualChange(isTextual)
+              if (dt !== 'NUMBER') onEditUnitChange('')
+            }}
+          />
+          {editInputType === 'INPUT' && !editIsTextual && (
             <Input
               value={editUnit}
               onChange={(e) => onEditUnitChange(e.target.value)}
@@ -632,10 +725,10 @@ function SortableFieldRow({
             <span
               className={cn(
                 'inline-flex rounded-full px-1.5 py-0.5 text-xs font-medium shrink-0',
-                FIELD_INPUT_TYPE_BADGE_COLOR[field.inputType],
+                FIELD_DISPLAY_TYPE_BADGE_COLOR[toDisplayType(field.inputType, field.isTextual)],
               )}
             >
-              {field.inputType === 'INPUT' ? 'Digitação' : 'Marcação'}
+              {FIELD_DISPLAY_TYPE_LABEL[toDisplayType(field.inputType, field.isTextual)]}
             </span>
             {field.unit && (
               <span className="text-xs text-muted-foreground shrink-0">{field.unit}</span>
@@ -683,11 +776,17 @@ export function TabularSheetEditor({
 }) {
   const [editingColId, setEditingColId] = useState<string | null>(null)
   const [editColName, setEditColName] = useState('')
+  const [editColInputType, setEditColInputType] = useState<MeasurementInputType>('INPUT')
+  const [editColIsTextual, setEditColIsTextual] = useState(false)
+  const [editColDefaultValue, setEditColDefaultValue] = useState('')
   const [editingRowId, setEditingRowId] = useState<string | null>(null)
   const [editRowName, setEditRowName] = useState('')
   const [editRowDefaultValue, setEditRowDefaultValue] = useState('')
   const [isAddingCol, setIsAddingCol] = useState(false)
   const [newColName, setNewColName] = useState('')
+  const [newColInputType, setNewColInputType] = useState<MeasurementInputType>('INPUT')
+  const [newColIsTextual, setNewColIsTextual] = useState(false)
+  const [newColDefaultValue, setNewColDefaultValue] = useState('')
   const [isAddingRow, setIsAddingRow] = useState(false)
   const [newRowName, setNewRowName] = useState('')
   const colEditRef = useRef<HTMLInputElement>(null)
@@ -721,7 +820,14 @@ export function TabularSheetEditor({
   async function confirmColEdit(colId: string) {
     if (!editColName.trim()) return
     try {
-      await updateColumn.mutateAsync({ sheetId: sheet.id, colId, name: editColName.trim() })
+      await updateColumn.mutateAsync({
+        sheetId: sheet.id,
+        colId,
+        name: editColName.trim(),
+        inputType: editColInputType,
+        isTextual: editColIsTextual,
+        defaultValue: editColIsTextual && editColDefaultValue.trim() ? editColDefaultValue.trim() : null,
+      })
       setEditingColId(null)
     } catch { toast.error('Erro ao atualizar coluna') }
   }
@@ -739,10 +845,15 @@ export function TabularSheetEditor({
       await createColumn.mutateAsync({
         sheetId: sheet.id,
         name: newColName.trim(),
-        inputType: 'INPUT',
+        inputType: newColInputType,
+        isTextual: newColIsTextual,
+        defaultValue: newColIsTextual && newColDefaultValue.trim() ? newColDefaultValue.trim() : undefined,
         order: columns.length + 1,
       })
       setNewColName('')
+      setNewColInputType('INPUT')
+      setNewColIsTextual(false)
+      setNewColDefaultValue('')
       setIsAddingCol(false)
     } catch { toast.error('Erro ao criar coluna') }
   }
@@ -798,46 +909,96 @@ export function TabularSheetEditor({
         <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1.5">Colunas</p>
         <div className="flex flex-wrap gap-1.5">
           {columns.map((col) => (
-            <div key={col.id} className="group inline-flex items-center gap-1 rounded-lg border bg-background px-2.5 py-1.5">
+            <div key={col.id} className="group inline-flex items-start gap-1 rounded-lg border bg-background px-2.5 py-1.5">
               {!isReadonly && editingColId === col.id ? (
-                <input
-                  ref={colEditRef}
-                  value={editColName}
-                  onChange={(e) => setEditColName(e.target.value)}
-                  className="w-24 text-xs border-none bg-transparent focus:outline-none"
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') { e.preventDefault(); void confirmColEdit(col.id) }
-                    if (e.key === 'Escape') setEditingColId(null)
-                  }}
-                  onBlur={() => void confirmColEdit(col.id)}
-                />
+                <div className="flex flex-col gap-1.5 min-w-[180px]">
+                  <input
+                    ref={colEditRef}
+                    value={editColName}
+                    onChange={(e) => setEditColName(e.target.value)}
+                    className="text-xs border-none bg-transparent focus:outline-none font-medium"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); void confirmColEdit(col.id) }
+                      if (e.key === 'Escape') setEditingColId(null)
+                    }}
+                  />
+                  <FieldTypeSelector
+                    value={toDisplayType(editColInputType, editColIsTextual)}
+                    onChange={(dt) => {
+                      const { inputType, isTextual } = fromDisplayType(dt)
+                      setEditColInputType(inputType)
+                      setEditColIsTextual(isTextual)
+                      if (!isTextual) setEditColDefaultValue('')
+                    }}
+                  />
+                  {editColIsTextual && (
+                    <input
+                      value={editColDefaultValue}
+                      onChange={(e) => setEditColDefaultValue(e.target.value)}
+                      placeholder="Placeholder padrão (ex: 00 cm acima do umbigo)"
+                      className="text-xs border rounded px-1.5 py-1 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
+                    />
+                  )}
+                  <div className="flex gap-1">
+                    <button type="button" onClick={() => void confirmColEdit(col.id)} className="rounded px-1.5 py-0.5 text-xs bg-primary text-primary-foreground hover:bg-primary/90">
+                      <Check className="h-3 w-3" />
+                    </button>
+                    <button type="button" onClick={() => setEditingColId(null)} className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground">
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                </div>
               ) : (
-                <span
-                  className={cn('text-xs font-medium', !isReadonly && 'cursor-pointer hover:text-primary')}
-                  onClick={!isReadonly ? () => { setEditingColId(col.id); setEditColName(col.name) } : undefined}
-                >
-                  {col.name}
-                </span>
-              )}
-              {!isReadonly && editingColId !== col.id && (
-                <button
-                  type="button"
-                  onClick={() => handleDeleteCol(col.id)}
-                  className="ml-0.5 hidden group-hover:flex items-center text-muted-foreground hover:text-destructive"
-                  aria-label="Remover coluna"
-                >
-                  <X className="h-3 w-3" />
-                </button>
+                <>
+                  <span
+                    className={cn('text-xs font-medium', !isReadonly && 'cursor-pointer hover:text-primary')}
+                    onClick={!isReadonly ? () => { setEditingColId(col.id); setEditColName(col.name); setEditColInputType(col.inputType); setEditColIsTextual(col.isTextual); setEditColDefaultValue(col.defaultValue ?? '') } : undefined}
+                  >
+                    {col.name}
+                  </span>
+                  <span className={cn('text-xs rounded-full px-1.5 py-0.5 font-medium shrink-0', FIELD_DISPLAY_TYPE_BADGE_COLOR[toDisplayType(col.inputType, col.isTextual)])}>
+                    {FIELD_DISPLAY_TYPE_LABEL[toDisplayType(col.inputType, col.isTextual)]}
+                  </span>
+                  {!isReadonly && (
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteCol(col.id)}
+                      className="ml-0.5 hidden group-hover:flex items-center text-muted-foreground hover:text-destructive"
+                      aria-label="Remover coluna"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
+                </>
               )}
             </div>
           ))}
           {!isReadonly && (
             <>
               {isAddingCol ? (
-                <form onSubmit={handleAddCol} className="inline-flex items-center gap-1">
-                  <Input value={newColName} onChange={(e) => setNewColName(e.target.value)} placeholder="Nome da coluna" className="h-7 w-32 text-xs" autoFocus onKeyDown={(e) => { if (e.key === 'Escape') { setIsAddingCol(false); setNewColName('') } }} />
-                  <Button type="submit" size="sm" className="h-7 px-2 text-xs" disabled={!newColName.trim()}><Check className="h-3 w-3" /></Button>
-                  <Button type="button" variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={() => { setIsAddingCol(false); setNewColName('') }}><X className="h-3 w-3" /></Button>
+                <form onSubmit={handleAddCol} className="inline-flex flex-col gap-1.5 rounded-lg border bg-background px-2.5 py-2 min-w-[200px]">
+                  <Input value={newColName} onChange={(e) => setNewColName(e.target.value)} placeholder="Nome da coluna" className="h-7 text-xs" autoFocus onKeyDown={(e) => { if (e.key === 'Escape') { setIsAddingCol(false); setNewColName('') } }} />
+                  <FieldTypeSelector
+                    value={toDisplayType(newColInputType, newColIsTextual)}
+                    onChange={(dt) => {
+                      const { inputType, isTextual } = fromDisplayType(dt)
+                      setNewColInputType(inputType)
+                      setNewColIsTextual(isTextual)
+                      if (!isTextual) setNewColDefaultValue('')
+                    }}
+                  />
+                  {newColIsTextual && (
+                    <Input
+                      value={newColDefaultValue}
+                      onChange={(e) => setNewColDefaultValue(e.target.value)}
+                      placeholder="Placeholder padrão (opcional)"
+                      className="h-7 text-xs"
+                    />
+                  )}
+                  <div className="flex gap-1">
+                    <Button type="submit" size="sm" className="h-7 px-2 text-xs" disabled={!newColName.trim()}><Check className="h-3 w-3" /></Button>
+                    <Button type="button" variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={() => { setIsAddingCol(false); setNewColName(''); setNewColInputType('INPUT'); setNewColIsTextual(false); setNewColDefaultValue('') }}><X className="h-3 w-3" /></Button>
+                  </div>
                 </form>
               ) : (
                 <button type="button" onClick={() => setIsAddingCol(true)} className="inline-flex items-center gap-1 rounded-lg border border-dashed px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:border-solid transition-colors">
@@ -854,25 +1015,34 @@ export function TabularSheetEditor({
         <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1.5">Campos (linhas)</p>
         <DndContext sensors={rowSensors} collisionDetection={closestCenter} onDragEnd={handleRowDragEnd}>
           <SortableContext items={activeFields.map((f) => f.id)} strategy={verticalListSortingStrategy}>
-            <div className="space-y-1">
-              {activeFields.map((field) => (
-                <SortableTabularRow
-                  key={field.id}
-                  field={field}
-                  isEditing={editingRowId === field.id}
-                  editName={editRowName}
-                  editDefaultValue={editRowDefaultValue}
-                  editRef={editingRowId === field.id ? rowEditRef : undefined}
-                  isReadonly={isReadonly}
-                  onStartEdit={() => { setEditingRowId(field.id); setEditRowName(field.name); setEditRowDefaultValue(field.defaultValue ?? '') }}
-                  onConfirm={() => confirmRowEdit(field.id)}
-                  onCancel={() => setEditingRowId(null)}
-                  onNameChange={setEditRowName}
-                  onDefaultValueChange={setEditRowDefaultValue}
-                  onDelete={() => handleDeleteRow(field.id)}
-                />
-              ))}
-            </div>
+            {(() => {
+              const textCols = columns.filter((c) => c.isTextual)
+              const hasTextColumn = textCols.length > 0
+              const textColumnNames = textCols.map((c) => c.name)
+              return (
+                <div className="space-y-1">
+                  {activeFields.map((field) => (
+                    <SortableTabularRow
+                      key={field.id}
+                      field={field}
+                      isEditing={editingRowId === field.id}
+                      editName={editRowName}
+                      editDefaultValue={editRowDefaultValue}
+                      editRef={editingRowId === field.id ? rowEditRef : undefined}
+                      isReadonly={isReadonly}
+                      hasTextColumn={hasTextColumn}
+                      textColumnNames={textColumnNames}
+                      onStartEdit={() => { setEditingRowId(field.id); setEditRowName(field.name); setEditRowDefaultValue(field.defaultValue ?? '') }}
+                      onConfirm={() => confirmRowEdit(field.id)}
+                      onCancel={() => setEditingRowId(null)}
+                      onNameChange={setEditRowName}
+                      onDefaultValueChange={setEditRowDefaultValue}
+                      onDelete={() => handleDeleteRow(field.id)}
+                    />
+                  ))}
+                </div>
+              )
+            })()}
           </SortableContext>
         </DndContext>
 
@@ -908,6 +1078,8 @@ function SortableTabularRow({
   editDefaultValue,
   editRef,
   isReadonly,
+  hasTextColumn,
+  textColumnNames,
   onStartEdit,
   onConfirm,
   onCancel,
@@ -921,6 +1093,8 @@ function SortableTabularRow({
   editDefaultValue: string
   editRef?: React.RefObject<HTMLInputElement | null>
   isReadonly: boolean
+  hasTextColumn: boolean
+  textColumnNames: string[]
   onStartEdit: () => void
   onConfirm: () => void
   onCancel: () => void
@@ -957,13 +1131,22 @@ function SortableTabularRow({
                   if (e.key === 'Tab') { e.preventDefault(); onConfirm() }
                 }}
               />
-              <Input
-                value={editDefaultValue}
-                onChange={(e) => onDefaultValueChange(e.target.value)}
-                placeholder="Valor padrão nesta linha (opcional)"
-                className="h-6 text-xs"
-                maxLength={500}
-              />
+              {hasTextColumn && (
+                <div className="space-y-0.5">
+                  <Input
+                    value={editDefaultValue}
+                    onChange={(e) => onDefaultValueChange(e.target.value)}
+                    placeholder={`Localização nesta linha (opcional)`}
+                    className="h-6 text-xs"
+                    maxLength={500}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Substitui o placeholder d{textColumnNames.length === 1
+                      ? `a coluna “${textColumnNames[0]}”`
+                      : `as colunas: ${textColumnNames.join(', ')}`}
+                  </p>
+                </div>
+              )}
             </div>
             <div className="flex gap-1 shrink-0">
               <Button type="button" size="sm" className="h-6 px-2 text-xs" onClick={onConfirm}>
@@ -980,7 +1163,7 @@ function SortableTabularRow({
               <span className={cn('text-sm font-medium', !isReadonly && 'cursor-pointer hover:text-primary')} onClick={!isReadonly ? onStartEdit : undefined}>
                 {field.name}
               </span>
-              {field.defaultValue && (
+              {field.defaultValue && hasTextColumn && (
                 <p className="text-xs text-muted-foreground truncate mt-0.5">{field.defaultValue}</p>
               )}
             </div>

--- a/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
+++ b/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
@@ -1141,7 +1141,7 @@ function EmptyEditorPlaceholder() {
   return (
     <div className="rounded-lg border bg-card h-full flex items-center justify-center py-16">
       <div className="text-center">
-        <Eye className="mx-auto mb-2 h-8 w-8 opacity-20" />
+        <ClipboardList className="mx-auto mb-2 h-8 w-8 opacity-20" />
         <p className="text-xs text-muted-foreground">Selecione uma ficha para visualizar</p>
       </div>
     </div>

--- a/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
+++ b/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
@@ -1252,7 +1252,7 @@ export function MeasurementSheetsSettings() {
           </nav>
         </aside>
 
-        <div className="w-64 shrink-0">
+        <div className="flex-1 min-w-0">
           <div className="rounded-lg border bg-card h-full flex flex-col">
             <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
               <h3 className="text-sm font-medium">Fichas — {CATEGORY_LABELS[selectedCategory]}</h3>
@@ -1300,7 +1300,7 @@ export function MeasurementSheetsSettings() {
           </div>
         </div>
 
-        <div className="hidden xl:flex xl:flex-1 xl:min-w-0">
+        <div className="hidden xl:block w-[400px] shrink-0">
           {selectedSheet ? (
             <SheetEditorPanel sheet={selectedSheet} isReadonly={isPersonalizada} onDeleted={() => setSelectedSheetId(null)} />
           ) : (

--- a/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
+++ b/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
@@ -37,7 +37,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Dialog, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Dialog, DialogTitle } from '@/components/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   Collapsible,
@@ -1122,7 +1122,7 @@ function SheetEditorPanel({
           <p className="text-sm text-muted-foreground mt-1">
             Esta ação não pode ser desfeita. Se a ficha tiver avaliações registradas, não será possível excluí-la — desative-a em vez disso.
           </p>
-          <DialogFooter className="mt-4">
+          <div className="flex justify-end gap-2 mt-4">
             <Button variant="outline" size="sm" onClick={() => setIsDeleteConfirmOpen(false)} disabled={deleteSheet.isPending}>
               Cancelar
             </Button>
@@ -1130,7 +1130,7 @@ function SheetEditorPanel({
               {deleteSheet.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
               Excluir
             </Button>
-          </DialogFooter>
+          </div>
         </Dialog>
       )}
     </div>

--- a/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
+++ b/aesthera/apps/web/app/(dashboard)/settings/_components/measurement-sheets-settings.tsx
@@ -3,7 +3,6 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
 import {
   GripVertical,
-  Eye,
   Plus,
   Loader2,
   ClipboardList,
@@ -17,6 +16,7 @@ import {
   X,
   ArrowUp,
   ArrowDown,
+  Pencil,
 } from 'lucide-react'
 import {
   DndContext,
@@ -37,7 +37,8 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Dialog, DialogTitle } from '@/components/ui/dialog'
+import { Dialog, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   Collapsible,
   CollapsibleTrigger,
@@ -46,6 +47,8 @@ import {
 import {
   useMeasurementSheets,
   useCreateMeasurementSheet,
+  useUpdateMeasurementSheet,
+  useDeleteMeasurementSheet,
   useReorderMeasurementSheets,
   useCreateMeasurementField,
   useUpdateMeasurementField,
@@ -94,8 +97,9 @@ function SortableSheetItem({
     <div
       ref={setNodeRef}
       style={style}
+      onClick={onSelect}
       className={cn(
-        'flex items-center gap-2 px-3 py-2.5 text-sm transition-colors',
+        'flex items-center gap-2 px-3 py-2.5 text-sm transition-colors cursor-pointer hover:bg-muted/50',
         selected && 'bg-primary/5',
       )}
     >
@@ -104,6 +108,7 @@ function SortableSheetItem({
           type="button"
           {...attributes}
           {...listeners}
+          onClick={(e) => e.stopPropagation()}
           className="cursor-grab active:cursor-grabbing shrink-0 touch-none focus:outline-none"
           aria-label="Reordenar"
         >
@@ -126,15 +131,6 @@ function SortableSheetItem({
         )}
         {SHEET_TYPE_LABELS[sheet.type]}
       </span>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-7 w-7 shrink-0"
-        onClick={onSelect}
-        aria-label="Visualizar ficha"
-      >
-        <Eye className={cn('h-3.5 w-3.5', selected && 'text-primary')} />
-      </Button>
     </div>
   )
 }
@@ -265,7 +261,7 @@ function NewSheetDialog({
   )
 }
 
-function SimpleSheetEditor({
+export function SimpleSheetEditor({
   sheet,
   isReadonly,
 }: {
@@ -678,7 +674,7 @@ function SortableFieldRow({
   )
 }
 
-function TabularSheetEditor({
+export function TabularSheetEditor({
   sheet,
   isReadonly,
 }: {
@@ -689,6 +685,7 @@ function TabularSheetEditor({
   const [editColName, setEditColName] = useState('')
   const [editingRowId, setEditingRowId] = useState<string | null>(null)
   const [editRowName, setEditRowName] = useState('')
+  const [editRowDefaultValue, setEditRowDefaultValue] = useState('')
   const [isAddingCol, setIsAddingCol] = useState(false)
   const [newColName, setNewColName] = useState('')
   const [isAddingRow, setIsAddingRow] = useState(false)
@@ -753,7 +750,12 @@ function TabularSheetEditor({
   async function confirmRowEdit(fieldId: string) {
     if (!editRowName.trim()) return
     try {
-      await updateField.mutateAsync({ sheetId: sheet.id, fieldId, name: editRowName.trim() })
+      await updateField.mutateAsync({
+        sheetId: sheet.id,
+        fieldId,
+        name: editRowName.trim(),
+        defaultValue: editRowDefaultValue.trim() || null,
+      })
       setEditingRowId(null)
     } catch { toast.error('Erro ao atualizar campo') }
   }
@@ -859,12 +861,14 @@ function TabularSheetEditor({
                   field={field}
                   isEditing={editingRowId === field.id}
                   editName={editRowName}
+                  editDefaultValue={editRowDefaultValue}
                   editRef={editingRowId === field.id ? rowEditRef : undefined}
                   isReadonly={isReadonly}
-                  onStartEdit={() => { setEditingRowId(field.id); setEditRowName(field.name) }}
+                  onStartEdit={() => { setEditingRowId(field.id); setEditRowName(field.name); setEditRowDefaultValue(field.defaultValue ?? '') }}
                   onConfirm={() => confirmRowEdit(field.id)}
                   onCancel={() => setEditingRowId(null)}
                   onNameChange={setEditRowName}
+                  onDefaultValueChange={setEditRowDefaultValue}
                   onDelete={() => handleDeleteRow(field.id)}
                 />
               ))}
@@ -901,23 +905,27 @@ function SortableTabularRow({
   field,
   isEditing,
   editName,
+  editDefaultValue,
   editRef,
   isReadonly,
   onStartEdit,
   onConfirm,
   onCancel,
   onNameChange,
+  onDefaultValueChange,
   onDelete,
 }: {
   field: MeasurementField
   isEditing: boolean
   editName: string
+  editDefaultValue: string
   editRef?: React.RefObject<HTMLInputElement | null>
   isReadonly: boolean
   onStartEdit: () => void
   onConfirm: () => void
   onCancel: () => void
   onNameChange: (v: string) => void
+  onDefaultValueChange: (v: string) => void
   onDelete: () => void
 }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
@@ -927,59 +935,204 @@ function SortableTabularRow({
   const style = { transform: CSS.Transform.toString(transform), transition }
 
   return (
-    <div ref={setNodeRef} style={style} className="flex items-center gap-2 rounded border bg-card px-2.5 py-1.5 text-sm">
-      {!isReadonly && (
-        <button type="button" {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing shrink-0 touch-none focus:outline-none" aria-label="Arrastar">
-          <GripVertical className="h-3.5 w-3.5 text-muted-foreground/40" />
-        </button>
-      )}
-      {isEditing ? (
-        <>
-          <input
-            ref={editRef}
-            value={editName}
-            onChange={(e) => onNameChange(e.target.value)}
-            className="flex-1 min-w-0 text-sm border-none bg-transparent focus:outline-none"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') { e.preventDefault(); onConfirm() }
-              if (e.key === 'Escape') onCancel()
-              if (e.key === 'Tab') { e.preventDefault(); onConfirm() }
-            }}
-            onBlur={onConfirm}
-          />
-          <button type="button" onClick={onCancel} className="shrink-0 text-muted-foreground hover:text-foreground">
-            <X className="h-3.5 w-3.5" />
+    <div ref={setNodeRef} style={style} className="rounded border bg-card px-2.5 py-1.5 text-sm">
+      <div className="flex items-center gap-2">
+        {!isReadonly && (
+          <button type="button" {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing shrink-0 touch-none focus:outline-none" aria-label="Arrastar">
+            <GripVertical className="h-3.5 w-3.5 text-muted-foreground/40" />
           </button>
-        </>
-      ) : (
-        <>
-          <span className={cn('flex-1 text-sm', !isReadonly && 'cursor-pointer hover:text-primary')} onClick={!isReadonly ? onStartEdit : undefined}>
-            {field.name}
-          </span>
-          {!isReadonly && (
-            <button type="button" onClick={onDelete} className="shrink-0 text-muted-foreground hover:text-destructive" aria-label="Remover">
-              <Trash2 className="h-3.5 w-3.5" />
-            </button>
-          )}
-        </>
-      )}
+        )}
+        {isEditing ? (
+          <>
+            <div className="flex-1 min-w-0 space-y-1.5">
+              <input
+                ref={editRef}
+                value={editName}
+                onChange={(e) => onNameChange(e.target.value)}
+                className="w-full text-sm border-none bg-transparent focus:outline-none font-medium"
+                placeholder="Nome do campo"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') { e.preventDefault(); onConfirm() }
+                  if (e.key === 'Escape') onCancel()
+                  if (e.key === 'Tab') { e.preventDefault(); onConfirm() }
+                }}
+              />
+              <Input
+                value={editDefaultValue}
+                onChange={(e) => onDefaultValueChange(e.target.value)}
+                placeholder="Valor padrão nesta linha (opcional)"
+                className="h-6 text-xs"
+                maxLength={500}
+              />
+            </div>
+            <div className="flex gap-1 shrink-0">
+              <Button type="button" size="sm" className="h-6 px-2 text-xs" onClick={onConfirm}>
+                <Check className="h-3 w-3" />
+              </Button>
+              <Button type="button" variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={onCancel}>
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex-1 min-w-0">
+              <span className={cn('text-sm font-medium', !isReadonly && 'cursor-pointer hover:text-primary')} onClick={!isReadonly ? onStartEdit : undefined}>
+                {field.name}
+              </span>
+              {field.defaultValue && (
+                <p className="text-xs text-muted-foreground truncate mt-0.5">{field.defaultValue}</p>
+              )}
+            </div>
+            {!isReadonly && (
+              <button type="button" onClick={onDelete} className="shrink-0 text-muted-foreground hover:text-destructive" aria-label="Remover">
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </>
+        )}
+      </div>
     </div>
   )
 }
 
-function SheetEditorPanel({ sheet, isReadonly }: { sheet: MeasurementSheet; isReadonly: boolean }) {
+function SheetEditorPanel({
+  sheet,
+  isReadonly,
+  onDeleted,
+}: {
+  sheet: MeasurementSheet
+  isReadonly: boolean
+  onDeleted: () => void
+}) {
+  const [isEditingMeta, setIsEditingMeta] = useState(false)
+  const [editName, setEditName] = useState(sheet.name)
+  const [editCategory, setEditCategory] = useState<MeasurementCategory>(sheet.category)
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
+
+  const updateSheet = useUpdateMeasurementSheet()
+  const deleteSheet = useDeleteMeasurementSheet()
+
+  // Sync quando a sheet muda (ex: outra ficha selecionada)
+  useEffect(() => {
+    setEditName(sheet.name)
+    setEditCategory(sheet.category)
+    setIsEditingMeta(false)
+  }, [sheet.id, sheet.name, sheet.category])
+
+  async function handleSaveMeta() {
+    if (!editName.trim()) return
+    const isDirty = editName.trim() !== sheet.name || editCategory !== sheet.category
+    if (!isDirty) { setIsEditingMeta(false); return }
+    try {
+      await updateSheet.mutateAsync({ id: sheet.id, name: editName.trim(), category: editCategory })
+      toast.success('Ficha atualizada')
+      setIsEditingMeta(false)
+    } catch (err: unknown) {
+      const d = (err as { response?: { data?: { error?: string } } })?.response?.data
+      if (d?.error === 'CONFLICT') toast.error('Já existe uma ficha com este nome')
+      else toast.error('Erro ao atualizar ficha')
+    }
+  }
+
+  async function handleDelete() {
+    try {
+      await deleteSheet.mutateAsync(sheet.id)
+      toast.success('Ficha excluída')
+      setIsDeleteConfirmOpen(false)
+      onDeleted()
+    } catch (err: unknown) {
+      const d = (err as { response?: { data?: { message?: string } } })?.response?.data
+      if (d?.message === 'HAS_HISTORY') {
+        toast.error('Esta ficha possui avaliações registradas. Para ocultá-la, desative-a.')
+      } else {
+        toast.error('Erro ao excluir ficha')
+      }
+      setIsDeleteConfirmOpen(false)
+    }
+  }
+
   return (
     <div className="rounded-lg border bg-card">
-      <div className="flex items-center gap-2 px-4 py-3 border-b">
-        {sheet.type === 'TABULAR' ? <Table2 className="h-4 w-4 text-muted-foreground" /> : <List className="h-4 w-4 text-muted-foreground" />}
-        <span className="text-sm font-medium truncate flex-1">{sheet.name}</span>
-        <span className={cn('inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium shrink-0', SHEET_TYPE_BADGE_COLOR[sheet.type])}>
-          {SHEET_TYPE_LABELS[sheet.type]}
-        </span>
+      {/* Header editável */}
+      <div className="px-4 py-3 border-b">
+        {isEditingMeta ? (
+          <div className="space-y-2">
+            <Input
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              className="h-8 text-sm font-medium"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') { e.preventDefault(); void handleSaveMeta() }
+                if (e.key === 'Escape') { setIsEditingMeta(false); setEditName(sheet.name); setEditCategory(sheet.category) }
+              }}
+            />
+            {!isReadonly && (
+              <Select value={editCategory} onValueChange={(v) => setEditCategory(v as MeasurementCategory)}>
+                <SelectTrigger className="h-7 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MEASUREMENT_CATEGORIES_ORDER.map((cat) => (
+                    <SelectItem key={cat} value={cat}>{CATEGORY_LABELS[cat]}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <div className="flex gap-2">
+              <Button type="button" size="sm" className="h-6 px-2 text-xs" onClick={handleSaveMeta} disabled={updateSheet.isPending || !editName.trim()}>
+                {updateSheet.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3 mr-0.5" />}
+                Salvar
+              </Button>
+              <Button type="button" variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => { setIsEditingMeta(false); setEditName(sheet.name); setEditCategory(sheet.category) }}>
+                Cancelar
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            {sheet.type === 'TABULAR' ? <Table2 className="h-4 w-4 text-muted-foreground shrink-0" /> : <List className="h-4 w-4 text-muted-foreground shrink-0" />}
+            <span className="text-sm font-medium truncate flex-1">{sheet.name}</span>
+            <span className={cn('inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium shrink-0', SHEET_TYPE_BADGE_COLOR[sheet.type])}>
+              {SHEET_TYPE_LABELS[sheet.type]}
+            </span>
+            {!isReadonly && (
+              <>
+                <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0 text-muted-foreground" onClick={() => setIsEditingMeta(true)} aria-label="Editar ficha">
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+                <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive" onClick={() => setIsDeleteConfirmOpen(true)} aria-label="Excluir ficha">
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </>
+            )}
+          </div>
+        )}
       </div>
+
       <div className="p-4">
         {sheet.type === 'SIMPLE' ? <SimpleSheetEditor sheet={sheet} isReadonly={isReadonly} /> : <TabularSheetEditor sheet={sheet} isReadonly={isReadonly} />}
       </div>
+
+      {/* Dialog de confirmação de exclusão */}
+      {isDeleteConfirmOpen && (
+        <Dialog open onClose={() => setIsDeleteConfirmOpen(false)} className="max-w-sm">
+          <DialogTitle>Excluir ficha?</DialogTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            Esta ação não pode ser desfeita. Se a ficha tiver avaliações registradas, não será possível excluí-la — desative-a em vez disso.
+          </p>
+          <DialogFooter className="mt-4">
+            <Button variant="outline" size="sm" onClick={() => setIsDeleteConfirmOpen(false)} disabled={deleteSheet.isPending}>
+              Cancelar
+            </Button>
+            <Button variant="destructive" size="sm" onClick={handleDelete} disabled={deleteSheet.isPending}>
+              {deleteSheet.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+              Excluir
+            </Button>
+          </DialogFooter>
+        </Dialog>
+      )}
     </div>
   )
 }
@@ -1099,7 +1252,7 @@ export function MeasurementSheetsSettings() {
           </nav>
         </aside>
 
-        <div className="flex-1 min-w-0">
+        <div className="w-64 shrink-0">
           <div className="rounded-lg border bg-card h-full flex flex-col">
             <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
               <h3 className="text-sm font-medium">Fichas — {CATEGORY_LABELS[selectedCategory]}</h3>
@@ -1147,9 +1300,9 @@ export function MeasurementSheetsSettings() {
           </div>
         </div>
 
-        <div className="hidden xl:block w-72 shrink-0">
+        <div className="hidden xl:flex xl:flex-1 xl:min-w-0">
           {selectedSheet ? (
-            <SheetEditorPanel sheet={selectedSheet} isReadonly={isPersonalizada} />
+            <SheetEditorPanel sheet={selectedSheet} isReadonly={isPersonalizada} onDeleted={() => setSelectedSheetId(null)} />
           ) : (
             <EmptyEditorPlaceholder />
           )}
@@ -1163,7 +1316,7 @@ export function MeasurementSheetsSettings() {
             {isEditorCollapsibleOpen ? <ChevronUp className="h-4 w-4 shrink-0 ml-2" /> : <ChevronDown className="h-4 w-4 shrink-0 ml-2" />}
           </CollapsibleTrigger>
           <CollapsibleContent className="mt-2">
-            <SheetEditorPanel sheet={selectedSheet} isReadonly={isPersonalizada} />
+            <SheetEditorPanel sheet={selectedSheet} isReadonly={isPersonalizada} onDeleted={() => setSelectedSheetId(null)} />
           </CollapsibleContent>
         </Collapsible>
       )}

--- a/aesthera/apps/web/components/body-measurements/evolution-tab.tsx
+++ b/aesthera/apps/web/components/body-measurements/evolution-tab.tsx
@@ -60,6 +60,7 @@ import {
 } from '@/lib/hooks/use-measurement-sessions'
 import { useAppointments } from '@/lib/hooks/use-appointments'
 import { NewCustomerSheetModal } from '@/components/measurement-sheets/NewCustomerSheetModal'
+import { CustomerSheetEditorDrawer } from '@/components/measurement-sheets/CustomerSheetEditorDrawer'
 
 // ──── Types ────────────────────────────────────────────────────────────────────
 
@@ -1695,6 +1696,7 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
   const [modalOpen, setModalOpen] = useState(false)
   const [editingSession, setEditingSession] = useState<MeasurementSession | undefined>()
   const [customSheetOpen, setCustomSheetOpen] = useState(false)
+  const [editingCustomerSheetId, setEditingCustomerSheetId] = useState<string | null>(null)
   const [categoryFilter, setCategoryFilter] = useState<MeasurementCategory | 'all'>('all')
 
   const { data: sessionsPage, isLoading: loadingSessions, error, refetch } = useMeasurementSessions(
@@ -1889,6 +1891,16 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
         <NewCustomerSheetModal
           customerId={customer.id}
           onClose={() => setCustomSheetOpen(false)}
+          onCreated={(sheetId) => { setCustomSheetOpen(false); setEditingCustomerSheetId(sheetId) }}
+        />
+      )}
+
+      {/* Editor de ficha personalizada após criação */}
+      {editingCustomerSheetId && (
+        <CustomerSheetEditorDrawer
+          customerId={customer.id}
+          sheetId={editingCustomerSheetId}
+          onClose={() => setEditingCustomerSheetId(null)}
         />
       )}
     </div>

--- a/aesthera/apps/web/components/body-measurements/evolution-tab.tsx
+++ b/aesthera/apps/web/components/body-measurements/evolution-tab.tsx
@@ -4,7 +4,6 @@ import { useRef, useState, useEffect } from 'react'
 import {
   AlertCircle,
   ArrowLeftRight,
-  BarChart2,
   ChevronDown,
   ChevronUp,
   ClipboardList,
@@ -115,18 +114,6 @@ function getCurrentUserId(): string | null {
   if (!token) return null
   const payload = decodeJwtPayload<{ sub?: string }>(token)
   return payload?.sub ?? null
-}
-
-function hasAnyValue(state: FormState): boolean {
-  for (const sheet of Object.values(state)) {
-    if (Object.values(sheet.simpleValues).some((v) => v !== '')) return true
-    if (Object.values(sheet.textualValues ?? {}).some((v) => v !== '')) return true
-    for (const cols of Object.values(sheet.tabularValues)) {
-      if (Object.values(cols).some((v) => v !== '')) return true
-    }
-    if (Object.values(sheet.checkValues ?? {}).some((v) => v)) return true
-  }
-  return false
 }
 
 // ──── Upload area ──────────────────────────────────────────────────────────────

--- a/aesthera/apps/web/components/body-measurements/evolution-tab.tsx
+++ b/aesthera/apps/web/components/body-measurements/evolution-tab.tsx
@@ -1692,6 +1692,11 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
   const isProfessional = role === 'professional'
   const currentUserId = getCurrentUserId()
 
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editingSession, setEditingSession] = useState<MeasurementSession | undefined>()
+  const [customSheetOpen, setCustomSheetOpen] = useState(false)
+  const [categoryFilter, setCategoryFilter] = useState<MeasurementCategory | 'all'>('all')
+
   const { data: sessionsPage, isLoading: loadingSessions, error, refetch } = useMeasurementSessions(
     customer.id,
     { limit: 50, category: categoryFilter !== 'all' ? categoryFilter : undefined },
@@ -1713,11 +1718,6 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
   })
   const hasConfirmedAppointment = (confirmedAppts?.total ?? 0) > 0 || (confirmedAppts?.items.length ?? 0) > 0
   const isProfessionalWithoutAppointment = isProfessional && !hasConfirmedAppointment
-
-  const [modalOpen, setModalOpen] = useState(false)
-  const [editingSession, setEditingSession] = useState<MeasurementSession | undefined>()
-  const [customSheetOpen, setCustomSheetOpen] = useState(false)
-  const [categoryFilter, setCategoryFilter] = useState<MeasurementCategory | 'all'>('all')
 
   const sessions = sessionsPage?.items ?? []
   const isLoading = loadingSessions

--- a/aesthera/apps/web/components/body-measurements/evolution-tab.tsx
+++ b/aesthera/apps/web/components/body-measurements/evolution-tab.tsx
@@ -44,7 +44,13 @@ import {
   useMeasurementSheets,
   type MeasurementSheet,
   type MeasurementSheetColumn,
+  type MeasurementCategory,
 } from '@/lib/hooks/use-measurement-sheets'
+import {
+  CATEGORY_LABELS,
+  CATEGORY_BADGE_COLOR,
+  MEASUREMENT_CATEGORIES_ORDER,
+} from '@/lib/measurement-categories'
 import {
   useMeasurementSessions,
   useCreateMeasurementSession,
@@ -53,6 +59,8 @@ import {
   type MeasurementSession,
   type MeasurementSessionFile,
 } from '@/lib/hooks/use-measurement-sessions'
+import { useAppointments } from '@/lib/hooks/use-appointments'
+import { NewCustomerSheetModal } from '@/components/measurement-sheets/NewCustomerSheetModal'
 
 // ──── Types ────────────────────────────────────────────────────────────────────
 
@@ -255,11 +263,17 @@ function SheetFormSection({
   state,
   onStateChange,
   defaultOpen = false,
+  selectable = false,
+  selected = false,
+  onSelectionChange,
 }: {
   sheet: MeasurementSheet
   state: SheetFormState
   onStateChange: (updater: SheetFormState | ((prev: SheetFormState) => SheetFormState)) => void
   defaultOpen?: boolean
+  selectable?: boolean
+  selected?: boolean
+  onSelectionChange?: (selected: boolean) => void
 }) {
   const [open, setOpen] = useState(defaultOpen)
   const activeFields = sheet.fields.filter((f) => f.active).sort((a, b) => a.order - b.order)
@@ -315,17 +329,32 @@ function SheetFormSection({
 
   return (
     <div className="rounded-xl border shadow-sm overflow-hidden">
-      <button
-        type="button"
-        className="w-full flex items-center justify-between px-4 py-3 bg-primary/5 border-b hover:bg-primary/10 transition-colors text-left"
-        onClick={() => setOpen((v) => !v)}
-      >
-        <div className="flex items-center gap-2">
-          <ClipboardList className="h-4 w-4 text-muted-foreground shrink-0" />
-          <span className="text-sm font-semibold">{sheet.name}</span>
-        </div>
-        {open ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
-      </button>
+      <div className="w-full flex items-center justify-between px-4 py-3 bg-primary/5 border-b hover:bg-primary/10 transition-colors">
+        {selectable && (
+          <input
+            type="checkbox"
+            aria-label={`Selecionar ficha ${sheet.name}`}
+            checked={selected}
+            onChange={(e) => {
+              onSelectionChange?.(e.target.checked)
+              if (e.target.checked) setOpen(true)
+            }}
+            onClick={(e) => e.stopPropagation()}
+            className="mr-2 h-4 w-4 shrink-0 rounded border-input cursor-pointer"
+          />
+        )}
+        <button
+          type="button"
+          className="flex-1 flex items-center justify-between text-left"
+          onClick={() => setOpen((v) => !v)}
+        >
+          <div className="flex items-center gap-2">
+            <ClipboardList className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span className="text-sm font-semibold">{sheet.name}</span>
+          </div>
+          {open ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
+        </button>
+      </div>
 
       {open && (
         <div className="px-4 py-4 space-y-4">
@@ -504,7 +533,7 @@ function SheetFormSection({
   )
 }
 
-// ──── Modal de nova/editar evolução ───────────────────────────────────────────
+// ──── Modal de nova/editar avaliação ─────────────────────────────────────────
 
 const sessionMetaSchema = z.object({
   recordedAt: z.string().min(1, 'Data obrigatória'),
@@ -512,14 +541,23 @@ const sessionMetaSchema = z.object({
 })
 type SessionMetaForm = z.infer<typeof sessionMetaSchema>
 
+/** Skeleton de carregamento para grupo de fichas */
+function SheetGroupSkeleton() {
+  return (
+    <div className="space-y-2">
+      {[...Array(2)].map((_, i) => (
+        <div key={i} className="h-12 rounded-xl border animate-pulse bg-muted/40" />
+      ))}
+    </div>
+  )
+}
+
 function SessionFormModal({
   customer,
-  sheets,
   sessionToEdit,
   onClose,
 }: {
   customer: Customer
-  sheets: MeasurementSheet[]
   sessionToEdit?: MeasurementSession
   onClose: () => void
 }) {
@@ -527,55 +565,78 @@ function SessionFormModal({
   const updateSession = useUpdateMeasurementSession()
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([])
   const [uploading, setUploading] = useState(false)
-  // Fotos já salvas na sessão em edição — preservadas e exibidas no formulário
   const [existingFiles, setExistingFiles] = useState<MeasurementSessionFile[]>(
     sessionToEdit?.files ?? [],
   )
   const [existingFileUrls, setExistingFileUrls] = useState<Record<string, string>>({})
 
-  // Pre-populate state for editing
+  // ── Buscar fichas ─────────────────────────────────────────────────────────
+  const { data: systemSheets = [], isLoading: loadingSystem } = useMeasurementSheets({ scope: 'SYSTEM' })
+  const { data: customerSheetsRaw = [], isLoading: loadingCustomer } = useMeasurementSheets({
+    scope: 'CUSTOMER',
+    customerId: customer.id,
+  })
+
+  const activeSystemSheets = systemSheets.filter((s) => s.active).sort((a, b) => a.order - b.order)
+  const activeCustomerSheets = customerSheetsRaw.filter((s) => s.active).sort((a, b) => a.order - b.order)
+  const allSheets = [...activeSystemSheets, ...activeCustomerSheets]
+  const hasAnySheet = activeSystemSheets.length > 0 || activeCustomerSheets.length > 0
+  const loadingSheets = loadingSystem || loadingCustomer
+
+  // ── Seleção de fichas ─────────────────────────────────────────────────────
+  const [selectedSheetIds, setSelectedSheetIds] = useState<Set<string>>(() => {
+    if (sessionToEdit) return new Set(sessionToEdit.sheetRecords.map((sr) => sr.sheetId))
+    return new Set()
+  })
+
+  const toggleSheetSelection = (sheetId: string, checked: boolean) => {
+    setSelectedSheetIds((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(sheetId)
+      else next.delete(sheetId)
+      return next
+    })
+  }
+
+  // ── Estado dos formulários — inicializado a partir da sessão em edição ────
   const buildInitialState = (): FormState => {
+    if (!sessionToEdit) return {}
     const result: FormState = {}
-    for (const sheet of sheets) {
+    for (const sr of sessionToEdit.sheetRecords) {
       const simpleValues: Record<string, string> = {}
       const textualValues: Record<string, string> = {}
       const tabularValues: Record<string, Record<string, string>> = {}
       const checkValues: Record<string, boolean> = {}
-      if (sessionToEdit) {
-        const sheetRecord = sessionToEdit.sheetRecords.find((sr) => sr.sheetId === sheet.id)
-        if (sheetRecord) {
-          for (const v of sheetRecord.values) {
-            if (v.field.inputType === 'CHECK') {
-              if (Number(v.value) === 1) checkValues[v.fieldId] = true
-            } else if (v.field.isTextual) {
-              textualValues[v.fieldId] = v.textValue ?? ''
-            } else {
-              simpleValues[v.fieldId] = String(Number(v.value ?? 0))
-            }
-          }
-          for (const v of sheetRecord.tabularValues) {
-            if (!tabularValues[v.fieldId]) tabularValues[v.fieldId] = {}
-            const colKey = v.subColumn ? `${v.sheetColumnId}::${v.subColumn}` : v.sheetColumnId
-            tabularValues[v.fieldId][colKey] = v.sheetColumn.isTextual
-              ? (v.textValue ?? '')
-              : String(Number(v.value ?? 0))
-          }
+      for (const v of sr.values) {
+        if (v.field.inputType === 'CHECK') {
+          if (Number(v.value) === 1) checkValues[v.fieldId] = true
+        } else if (v.field.isTextual) {
+          textualValues[v.fieldId] = v.textValue ?? ''
+        } else {
+          simpleValues[v.fieldId] = String(Number(v.value ?? 0))
         }
       }
-      result[sheet.id] = { simpleValues, textualValues, tabularValues, checkValues }
+      for (const v of sr.tabularValues) {
+        if (!tabularValues[v.fieldId]) tabularValues[v.fieldId] = {}
+        const colKey = v.subColumn ? `${v.sheetColumnId}::${v.subColumn}` : v.sheetColumnId
+        tabularValues[v.fieldId][colKey] = v.sheetColumn.isTextual
+          ? (v.textValue ?? '')
+          : String(Number(v.value ?? 0))
+      }
+      result[sr.sheetId] = { simpleValues, textualValues, tabularValues, checkValues }
     }
     return result
   }
 
   const [formState, setFormState] = useState<FormState>(buildInitialState)
 
-  // Cleanup object URLs when modal closes
+  // Cleanup object URLs
   useEffect(() => {
     return () => { pendingFiles.forEach((f) => URL.revokeObjectURL(f.preview)) }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Carrega URLs das fotos já salvas para exibição no formulário de edição
+  // Carrega URLs das fotos já salvas
   useEffect(() => {
     if (existingFiles.length === 0) return
     let cancelled = false
@@ -599,7 +660,7 @@ function SessionFormModal({
     },
   })
 
-  const hasUnsaved = metaDirty || hasAnyValue(formState) || pendingFiles.length > 0
+  const hasUnsaved = metaDirty || selectedSheetIds.size > 0 || pendingFiles.length > 0
 
   const doUploadFiles = async (): Promise<string[]> => {
     const confirmedIds: string[] = []
@@ -650,6 +711,11 @@ function SessionFormModal({
   }
 
   const onSubmit = handleSubmit(async (meta) => {
+    if (selectedSheetIds.size === 0) {
+      toast.error('Selecione ao menos uma ficha.')
+      return
+    }
+
     const withoutCategory = pendingFiles.filter((f) => !f.category)
     if (withoutCategory.length > 0) {
       toast.error('Selecione a categoria de todos os arquivos antes de salvar.')
@@ -659,27 +725,24 @@ function SessionFormModal({
     setUploading(true)
     try {
       const newFileIds = await doUploadFiles()
-      // Combina IDs das fotos existentes (preservadas) + novas uploadadas
       const fileIds = [...existingFiles.map((f) => f.id), ...newFileIds]
 
-      const sheetRecords = Object.entries(formState)
-        .map(([sheetId, state]) => {
-          const sheetDef = (sheets ?? []).find((s: MeasurementSheet) => s.id === sheetId)
-          // Valores SIMPLES (numéricos e textuais)
+      const sheetRecords = [...selectedSheetIds]
+        .map((sheetId) => {
+          const state = formState[sheetId]
+          if (!state) return null
+          const sheetDef = allSheets.find((s: MeasurementSheet) => s.id === sheetId)
           const values = [
             ...Object.entries(state.simpleValues)
               .filter(([, v]) => v !== '' && !isNaN(Number(v)))
               .map(([fieldId, value]) => ({ fieldId, value: Number(value) })),
-            // Campos textuais SIMPLES
             ...Object.entries(state.textualValues ?? {})
               .filter(([, v]) => v !== '')
               .map(([fieldId, textValue]) => ({ fieldId, textValue })),
-            // M-04: CHECK fields
             ...Object.entries(state.checkValues ?? {})
               .filter(([, checked]) => checked)
               .map(([fieldId]) => ({ fieldId, value: 1 })),
           ]
-          // Valores TABULARES: colKey pode ser "colId" ou "colId::subCol"
           const tabularValues = Object.entries(state.tabularValues).flatMap(([fieldId, cols]) =>
             Object.entries(cols)
               .filter(([, v]) => v !== '' && v !== '0')
@@ -705,9 +768,8 @@ function SessionFormModal({
           tabularValues: Array<{ fieldId: string; columnId: string; subColumn: string; value?: number; textValue?: string }>
         }>
 
-      // Validar aqui (após montar sheetRecords) para garantir que ao menos 1 valor real foi preenchido
       if (sheetRecords.length === 0) {
-        toast.error('Preencha ao menos um valor antes de salvar.')
+        toast.error('Preencha ao menos um valor nas fichas selecionadas.')
         setUploading(false)
         return
       }
@@ -721,7 +783,7 @@ function SessionFormModal({
           sheetRecords,
           fileIds,
         })
-        toast.success('Registros de evolução atualizados')
+        toast.success('Avaliação atualizada com sucesso')
       } else {
         await createSession.mutateAsync({
           customerId: customer.id,
@@ -730,7 +792,7 @@ function SessionFormModal({
           sheetRecords,
           fileIds,
         })
-        toast.success('Registro de evolução salvo com sucesso')
+        toast.success('Avaliação registrada com sucesso')
       }
       onClose()
     } catch (err: unknown) {
@@ -738,7 +800,7 @@ function SessionFormModal({
       if (code === 'EMPTY_SESSION') {
         toast.error('Preencha ao menos um valor antes de salvar.')
       } else {
-        toast.error('Erro ao salvar registro')
+        toast.error('Erro ao salvar avaliação')
       }
     } finally {
       setUploading(false)
@@ -746,7 +808,7 @@ function SessionFormModal({
   })
 
   const isPending = uploading || createSession.isPending || updateSession.isPending
-  const title = sessionToEdit ? 'Editar registro de evolução' : 'Novo registro de evolução'
+  const title = sessionToEdit ? 'Editar avaliação' : 'Nova avaliação'
 
   return (
     <Dialog open onClose={onClose} isDirty={hasUnsaved} className="p-0 max-w-2xl">
@@ -766,23 +828,78 @@ function SessionFormModal({
             {errors.recordedAt && <p className="text-xs text-destructive">{errors.recordedAt.message}</p>}
           </div>
 
-          {/* Fitas por ficha */}
-          {sheets
-            .filter((s) => s.active)
-            .sort((a, b) => a.order - b.order)
-            .map((sheet, index) => (
-              <SheetFormSection
-                key={sheet.id}
-                sheet={sheet}
-                state={formState[sheet.id] ?? { simpleValues: {}, tabularValues: {}, checkValues: {}, textualValues: {} }}
-                onStateChange={(updater) => setFormState((prev) => {
-                  const current = prev[sheet.id] ?? { simpleValues: {}, tabularValues: {}, checkValues: {}, textualValues: {} }
-                  const next = typeof updater === 'function' ? updater(current) : updater
-                  return { ...prev, [sheet.id]: next }
-                })}
-                defaultOpen={index === 0}
-              />
-            ))}
+          {/* Empty state — sem fichas ativas */}
+          {!loadingSheets && !hasAnySheet && (
+            <div className="rounded-lg border bg-card py-8 text-center text-muted-foreground">
+              <ClipboardList className="mx-auto mb-2 h-8 w-8 opacity-30" />
+              <p className="text-sm">
+                Nenhuma ficha ativa. Configure fichas em{' '}
+                <span className="font-medium">Configurações &gt; Fichas de Avaliação</span>.
+              </p>
+            </div>
+          )}
+
+          {/* Fichas da Clínica */}
+          {(loadingSystem || activeSystemSheets.length > 0) && (
+            <div className="space-y-3">
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                Fichas da Clínica
+              </p>
+              {loadingSystem ? (
+                <SheetGroupSkeleton />
+              ) : (
+                activeSystemSheets.map((sheet, index) => (
+                  <SheetFormSection
+                    key={sheet.id}
+                    sheet={sheet}
+                    state={formState[sheet.id] ?? { simpleValues: {}, tabularValues: {}, checkValues: {}, textualValues: {} }}
+                    onStateChange={(updater) =>
+                      setFormState((prev) => {
+                        const current = prev[sheet.id] ?? { simpleValues: {}, tabularValues: {}, checkValues: {}, textualValues: {} }
+                        const next = typeof updater === 'function' ? updater(current) : updater
+                        return { ...prev, [sheet.id]: next }
+                      })
+                    }
+                    defaultOpen={index === 0 && selectedSheetIds.size === 0}
+                    selectable
+                    selected={selectedSheetIds.has(sheet.id)}
+                    onSelectionChange={(checked) => toggleSheetSelection(sheet.id, checked)}
+                  />
+                ))
+              )}
+            </div>
+          )}
+
+          {/* Fichas deste Cliente */}
+          {(loadingCustomer || activeCustomerSheets.length > 0) && (
+            <div className="space-y-3">
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                Fichas deste Cliente
+              </p>
+              {loadingCustomer ? (
+                <SheetGroupSkeleton />
+              ) : (
+                activeCustomerSheets.map((sheet) => (
+                  <SheetFormSection
+                    key={sheet.id}
+                    sheet={sheet}
+                    state={formState[sheet.id] ?? { simpleValues: {}, tabularValues: {}, checkValues: {}, textualValues: {} }}
+                    onStateChange={(updater) =>
+                      setFormState((prev) => {
+                        const current = prev[sheet.id] ?? { simpleValues: {}, tabularValues: {}, checkValues: {}, textualValues: {} }
+                        const next = typeof updater === 'function' ? updater(current) : updater
+                        return { ...prev, [sheet.id]: next }
+                      })
+                    }
+                    defaultOpen={false}
+                    selectable
+                    selected={selectedSheetIds.has(sheet.id)}
+                    onSelectionChange={(checked) => toggleSheetSelection(sheet.id, checked)}
+                  />
+                ))
+              )}
+            </div>
+          )}
 
           {/* Observações */}
           <div className="space-y-1.5">
@@ -799,7 +916,6 @@ function SessionFormModal({
           {/* Upload de fotos */}
           <div>
             <p className="text-sm font-medium mb-3">Fotos</p>
-            {/* Fotos já salvas (edição) */}
             {existingFiles.length > 0 && (
               <div className="space-y-2 mb-3">
                 <p className="text-xs text-muted-foreground">Fotos salvas</p>
@@ -837,15 +953,16 @@ function SessionFormModal({
           <Button type="button" variant="outline" size="sm" onClick={onClose} disabled={isPending}>
             Cancelar
           </Button>
-          <Button type="submit" size="sm" disabled={isPending}>
+          <Button type="submit" size="sm" disabled={isPending || selectedSheetIds.size === 0}>
             {isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
-            {sessionToEdit ? 'Salvar alterações' : 'Salvar registro'}
+            {sessionToEdit ? 'Salvar alterações' : 'Salvar avaliação'}
           </Button>
         </div>
       </form>
     </Dialog>
   )
 }
+
 
 // ──── Modal de comparação ──────────────────────────────────────────────────────
 
@@ -1264,10 +1381,13 @@ function SessionCard({
     (sum, sr) => sum + sr.tabularValues.length,
     0,
   )
-  const sheetBadges = session.sheetRecords.map((sr) => ({
-    name: sr.sheet.name,
-    isTabular: sr.tabularValues.length > 0,
-  }))
+
+  // Categorias únicas presentes nesta sessão (derivadas das fichas dos registros)
+  const sessionCategories = [
+    ...new Set(
+      session.sheetRecords.map((sr) => sr.sheet.category as MeasurementCategory),
+    ),
+  ]
 
   const handleExpand = () => {
     setExpanded((v) => !v)
@@ -1284,12 +1404,13 @@ function SessionCard({
         <div className="text-left">
           <p className="text-sm font-medium">{formatDate(session.recordedAt)}</p>
           <div className="flex items-center gap-1.5 flex-wrap mt-0.5">
-            {sheetBadges.map((badge) => (
+            {/* Badges de categoria */}
+            {sessionCategories.map((cat) => (
               <span
-                key={badge.name}
-                className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] ${badge.isTabular ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' : 'bg-muted text-muted-foreground'}`}
+                key={cat}
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${CATEGORY_BADGE_COLOR[cat] ?? 'bg-muted text-muted-foreground'}`}
               >
-                {badge.name}
+                {CATEGORY_LABELS[cat] ?? cat}
               </span>
             ))}
             {totalSimpleValues > 0 && (
@@ -1573,29 +1694,51 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
   const role = useRole()
   const isAdmin = role === 'admin'
   const isStaff = role === 'staff'
+  const isProfessional = role === 'professional'
   const currentUserId = getCurrentUserId()
 
-  const { data: sheetsData = [], isLoading: loadingSheets } = useMeasurementSheets()
   const { data: sessionsPage, isLoading: loadingSessions, error, refetch } = useMeasurementSessions(
     customer.id,
     { limit: 50 },
   )
   const deleteSession = useDeleteMeasurementSession()
 
+  // Fichas CUSTOMER deste cliente — para checar o limite de 10
+  const { data: customerSheets = [] } = useMeasurementSheets({
+    scope: 'CUSTOMER',
+    customerId: customer.id,
+  })
+  const isAtCustomLimit = customerSheets.filter((s) => s.active).length >= 10
+
+  // Agendamentos confirmados com este cliente — para autorizar profissional criar ficha personalizada
+  const { data: confirmedAppts } = useAppointments({
+    customerId: customer.id,
+    status: 'confirmed,in_progress,completed',
+    limit: '1',
+  })
+  const hasConfirmedAppointment = (confirmedAppts?.total ?? 0) > 0 || (confirmedAppts?.items.length ?? 0) > 0
+  const isProfessionalWithoutAppointment = isProfessional && !hasConfirmedAppointment
+
   const [modalOpen, setModalOpen] = useState(false)
   const [editingSession, setEditingSession] = useState<MeasurementSession | undefined>()
+  const [customSheetOpen, setCustomSheetOpen] = useState(false)
+  const [categoryFilter, setCategoryFilter] = useState<MeasurementCategory | 'all'>('all')
 
-  const activeSheets = sheetsData.filter((s) => s.active).sort((a, b) => a.order - b.order)
   const sessions = sessionsPage?.items ?? []
-  const isLoading = loadingSheets || loadingSessions
-  const canCreate = isAdmin || isStaff
+  const isLoading = loadingSessions
+
+  const filteredSessions = categoryFilter === 'all'
+    ? sessions
+    : sessions.filter((s) =>
+        s.sheetRecords.some((sr) => sr.sheet.category === categoryFilter),
+      )
 
   const handleDelete = async (session: MeasurementSession) => {
     try {
       await deleteSession.mutateAsync({ id: session.id, customerId: customer.id })
-      toast.success('Registro excluído com sucesso')
+      toast.success('Avaliação excluída com sucesso')
     } catch {
-      toast.error('Erro ao excluir registro')
+      toast.error('Erro ao excluir avaliação')
     }
   }
 
@@ -1606,14 +1749,14 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
         <div className="flex flex-col items-center justify-center py-10 text-center gap-2">
           <AlertCircle className="h-8 w-8 text-muted-foreground/40" />
           <p className="text-sm text-muted-foreground">
-            Você não tem permissão para visualizar os dados de evolução deste cliente.
+            Você não tem permissão para visualizar as avaliações deste cliente.
           </p>
         </div>
       )
     }
     return (
       <div className="py-6 text-center text-sm text-muted-foreground space-y-3">
-        <p>Erro ao carregar registros de evolução.</p>
+        <p>Erro ao carregar avaliações.</p>
         <Button variant="outline" size="sm" onClick={() => void refetch()}>
           <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
           Tentar novamente
@@ -1624,58 +1767,108 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <p className="text-sm font-semibold">Evolução corporal</p>
-        {canCreate && (
-          <Button size="sm" onClick={() => { setEditingSession(undefined); setModalOpen(true) }} disabled={isLoading}>
+      {/* Header com botões */}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex gap-2 flex-wrap">
+          {/* Botão nova avaliação */}
+          <Button
+            size="sm"
+            onClick={() => { setEditingSession(undefined); setModalOpen(true) }}
+            disabled={isLoading}
+          >
             <Plus className="mr-1 h-3.5 w-3.5" />
-            Novo registro
+            Nova avaliação
           </Button>
-        )}
+
+          {/* Botão nova ficha deste cliente */}
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={isProfessionalWithoutAppointment || isAtCustomLimit}
+            title={
+              isProfessionalWithoutAppointment
+                ? 'Você não tem agendamento confirmado com este cliente'
+                : isAtCustomLimit
+                ? 'Limite de 10 fichas personalizadas atingido'
+                : undefined
+            }
+            onClick={() => setCustomSheetOpen(true)}
+          >
+            Nova ficha deste cliente
+          </Button>
+        </div>
       </div>
 
-      {/* Estados */}
+      {/* Loading */}
       {isLoading ? (
         <div className="flex justify-center py-8">
           <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
         </div>
-      ) : activeSheets.length === 0 ? (
-        <div className="rounded-xl border border-dashed p-8 text-center">
-          <BarChart2 className="mx-auto mb-2 h-8 w-8 text-muted-foreground/40" />
-          <p className="text-sm text-muted-foreground">
-            Configure as fichas de avaliação em{' '}
-            <span className="font-medium">Configurações → Medidas Corporais</span> para começar a registrar.
-          </p>
-        </div>
       ) : sessions.length === 0 ? (
-        <div className="rounded-xl border border-dashed p-8 text-center">
-          <BarChart2 className="mx-auto mb-2 h-8 w-8 text-muted-foreground/40" />
-          <p className="text-sm text-muted-foreground mb-2">Nenhum registro de evolução.</p>
-          {canCreate && (
-            <Button size="sm" onClick={() => { setEditingSession(undefined); setModalOpen(true) }}>
-              <Plus className="mr-1 h-3.5 w-3.5" />
-              Novo registro
-            </Button>
-          )}
+        /* Empty state */
+        <div className="rounded-lg border bg-card py-16 text-center text-muted-foreground">
+          <ClipboardList className="mx-auto mb-2 h-8 w-8 opacity-30" />
+          <p className="text-sm">Nenhuma avaliação registrada.</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3"
+            onClick={() => { setEditingSession(undefined); setModalOpen(true) }}
+          >
+            Nova avaliação
+          </Button>
         </div>
       ) : (
         <div className="space-y-3">
-          {sessions.map((session, _i) => {
-            const canEdit = isAdmin || isStaff || session.createdById === currentUserId
-            return (
-              <SessionCard
-                key={session.id}
-                session={session}
-                allSessions={sessions}
-                canEdit={canEdit}
-                isAdmin={isAdmin}
-                onEdit={() => { setEditingSession(session); setModalOpen(true) }}
-                onDelete={() => void handleDelete(session)}
-                sheets={activeSheets}
-              />
-            )
-          })}
+          {/* Pills de filtro por categoria */}
+          <div className="flex flex-wrap gap-1.5">
+            {(['all', ...MEASUREMENT_CATEGORIES_ORDER] as const).map((cat) => (
+              <button
+                key={cat}
+                type="button"
+                onClick={() => setCategoryFilter(cat)}
+                className={[
+                  'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+                  categoryFilter === cat
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-input bg-background hover:bg-accent',
+                ].join(' ')}
+              >
+                {cat === 'all' ? 'Todas' : CATEGORY_LABELS[cat]}
+              </button>
+            ))}
+          </div>
+
+          {/* Lista de sessões filtradas */}
+          {filteredSessions.length === 0 ? (
+            <div className="rounded-lg border bg-card py-10 text-center text-muted-foreground">
+              <p className="text-sm">Nenhuma avaliação nesta categoria.</p>
+              <button
+                type="button"
+                className="mt-2 text-xs text-primary underline"
+                onClick={() => setCategoryFilter('all')}
+              >
+                Ver todas
+              </button>
+            </div>
+          ) : (
+            filteredSessions.map((session) => {
+              const canEdit = isAdmin || isStaff || session.createdById === currentUserId
+              return (
+                <SessionCard
+                  key={session.id}
+                  session={session}
+                  allSessions={sessions}
+                  canEdit={canEdit}
+                  isAdmin={isAdmin}
+                  onEdit={() => { setEditingSession(session); setModalOpen(true) }}
+                  onDelete={() => void handleDelete(session)}
+                  sheets={[]}
+                />
+              )
+            })
+          )}
+
           {sessions.length >= 50 && (
             <p className="text-center text-xs text-muted-foreground pt-1">
               Exibindo os 50 registros mais recentes.
@@ -1684,13 +1877,20 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
         </div>
       )}
 
-      {/* Modal de formulário */}
+      {/* Modal de nova/editar avaliação */}
       {modalOpen && (
         <SessionFormModal
           customer={customer}
-          sheets={activeSheets}
           sessionToEdit={editingSession}
           onClose={() => { setModalOpen(false); setEditingSession(undefined) }}
+        />
+      )}
+
+      {/* Modal de nova ficha personalizada */}
+      {customSheetOpen && (
+        <NewCustomerSheetModal
+          customerId={customer.id}
+          onClose={() => setCustomSheetOpen(false)}
         />
       )}
     </div>

--- a/aesthera/apps/web/components/body-measurements/evolution-tab.tsx
+++ b/aesthera/apps/web/components/body-measurements/evolution-tab.tsx
@@ -571,6 +571,9 @@ function SessionFormModal({
   const loadingSheets = loadingSystem || loadingCustomer
 
   // ── Seleção de fichas ─────────────────────────────────────────────────────
+  const initialSelectedIdsRef = useRef(
+    sessionToEdit ? new Set(sessionToEdit.sheetRecords.map((sr) => sr.sheetId)) : new Set<string>(),
+  )
   const [selectedSheetIds, setSelectedSheetIds] = useState<Set<string>>(() => {
     if (sessionToEdit) return new Set(sessionToEdit.sheetRecords.map((sr) => sr.sheetId))
     return new Set()
@@ -647,7 +650,12 @@ function SessionFormModal({
     },
   })
 
-  const hasUnsaved = metaDirty || selectedSheetIds.size > 0 || pendingFiles.length > 0
+  const hasUnsaved = metaDirty || (() => {
+    const init = initialSelectedIdsRef.current
+    if (init.size !== selectedSheetIds.size) return true
+    for (const id of init) if (!selectedSheetIds.has(id)) return true
+    return false
+  })() || pendingFiles.length > 0
 
   const doUploadFiles = async (): Promise<string[]> => {
     const confirmedIds: string[] = []
@@ -1686,7 +1694,7 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
 
   const { data: sessionsPage, isLoading: loadingSessions, error, refetch } = useMeasurementSessions(
     customer.id,
-    { limit: 50 },
+    { limit: 50, category: categoryFilter !== 'all' ? categoryFilter : undefined },
   )
   const deleteSession = useDeleteMeasurementSession()
 
@@ -1713,12 +1721,9 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
 
   const sessions = sessionsPage?.items ?? []
   const isLoading = loadingSessions
+  const canCreate = isAdmin || isStaff
 
-  const filteredSessions = categoryFilter === 'all'
-    ? sessions
-    : sessions.filter((s) =>
-        s.sheetRecords.some((sr) => sr.sheet.category === categoryFilter),
-      )
+  // Filtro é server-side — sessions já chegam filtrados por categoria
 
   const handleDelete = async (session: MeasurementSession) => {
     try {
@@ -1757,15 +1762,17 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
       {/* Header com botões */}
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <div className="flex gap-2 flex-wrap">
-          {/* Botão nova avaliação */}
-          <Button
-            size="sm"
-            onClick={() => { setEditingSession(undefined); setModalOpen(true) }}
-            disabled={isLoading}
-          >
-            <Plus className="mr-1 h-3.5 w-3.5" />
-            Nova avaliação
-          </Button>
+          {/* Botão nova avaliação — apenas admin e staff */}
+          {canCreate && (
+            <Button
+              size="sm"
+              onClick={() => { setEditingSession(undefined); setModalOpen(true) }}
+              disabled={isLoading}
+            >
+              <Plus className="mr-1 h-3.5 w-3.5" />
+              Nova avaliação
+            </Button>
+          )}
 
           {/* Botão nova ficha deste cliente */}
           <Button
@@ -1791,19 +1798,21 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
         <div className="flex justify-center py-8">
           <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
         </div>
-      ) : sessions.length === 0 ? (
-        /* Empty state */
+      ) : sessions.length === 0 && categoryFilter === 'all' ? (
+        /* Empty state principal — sem registros */
         <div className="rounded-lg border bg-card py-16 text-center text-muted-foreground">
           <ClipboardList className="mx-auto mb-2 h-8 w-8 opacity-30" />
           <p className="text-sm">Nenhuma avaliação registrada.</p>
-          <Button
-            variant="outline"
-            size="sm"
-            className="mt-3"
-            onClick={() => { setEditingSession(undefined); setModalOpen(true) }}
-          >
-            Nova avaliação
-          </Button>
+          {canCreate && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              onClick={() => { setEditingSession(undefined); setModalOpen(true) }}
+            >
+              Nova avaliação
+            </Button>
+          )}
         </div>
       ) : (
         <div className="space-y-3">
@@ -1826,20 +1835,22 @@ export function EvolutionTab({ customer }: { customer: Customer }) {
             ))}
           </div>
 
-          {/* Lista de sessões filtradas */}
-          {filteredSessions.length === 0 ? (
+          {/* Lista de sessões (já filtradas server-side pela categoria) */}
+          {sessions.length === 0 ? (
+            /* Empty state de categoria — sem registros para o filtro atual */
             <div className="rounded-lg border bg-card py-10 text-center text-muted-foreground">
               <p className="text-sm">Nenhuma avaliação nesta categoria.</p>
-              <button
-                type="button"
-                className="mt-2 text-xs text-primary underline"
+              <Button
+                variant="link"
+                size="sm"
+                className="mt-2 h-auto p-0 text-xs"
                 onClick={() => setCategoryFilter('all')}
               >
                 Ver todas
-              </button>
+              </Button>
             </div>
           ) : (
-            filteredSessions.map((session) => {
+            sessions.map((session) => {
               const canEdit = isAdmin || isStaff || session.createdById === currentUserId
               return (
                 <SessionCard

--- a/aesthera/apps/web/components/measurement-sheets/CustomerSheetEditorDrawer.tsx
+++ b/aesthera/apps/web/components/measurement-sheets/CustomerSheetEditorDrawer.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { Loader2, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogTitle } from '@/components/ui/dialog'
+import { useMeasurementSheets } from '@/lib/hooks/use-measurement-sheets'
+import { SimpleSheetEditor } from '@/app/(dashboard)/settings/_components/measurement-sheets-settings'
+import { TabularSheetEditor } from '@/app/(dashboard)/settings/_components/measurement-sheets-settings'
+
+// ──── Props ────────────────────────────────────────────────────────────────────
+
+interface CustomerSheetEditorDrawerProps {
+  customerId: string
+  sheetId: string
+  onClose: () => void
+}
+
+// ──── Component ────────────────────────────────────────────────────────────────
+
+export function CustomerSheetEditorDrawer({
+  customerId,
+  sheetId,
+  onClose,
+}: CustomerSheetEditorDrawerProps) {
+  const { data: sheets = [], isLoading } = useMeasurementSheets({
+    scope: 'CUSTOMER',
+    customerId,
+    includeInactive: true,
+  })
+
+  const sheet = sheets.find((s) => s.id === sheetId)
+
+  return (
+    <Dialog open onClose={onClose} className="max-w-2xl p-0">
+      <div className="sticky top-0 bg-card border-b px-6 py-4 flex items-center justify-between rounded-t-xl z-10">
+        <DialogTitle className="mb-0 truncate">
+          {sheet ? sheet.name : 'Editar ficha'}
+        </DialogTitle>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          className="h-7 w-7 shrink-0 text-muted-foreground"
+          aria-label="Fechar"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="p-6">
+        {isLoading ? (
+          <div className="flex justify-center py-12">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : !sheet ? (
+          <p className="text-sm text-muted-foreground text-center py-8">
+            Ficha não encontrada.
+          </p>
+        ) : sheet.type === 'SIMPLE' ? (
+          <SimpleSheetEditor sheet={sheet} isReadonly={false} />
+        ) : (
+          <TabularSheetEditor sheet={sheet} isReadonly={false} />
+        )}
+      </div>
+
+      <div className="sticky bottom-0 bg-card border-t px-6 py-4 flex justify-end rounded-b-xl">
+        <Button type="button" size="sm" onClick={onClose}>
+          Concluído
+        </Button>
+      </div>
+    </Dialog>
+  )
+}

--- a/aesthera/apps/web/components/measurement-sheets/NewCustomerSheetModal.tsx
+++ b/aesthera/apps/web/components/measurement-sheets/NewCustomerSheetModal.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { InfoBanner } from '@/components/ui/info-banner'
 import { useCreateMeasurementSheet } from '@/lib/hooks/use-measurement-sheets'
 import { useQueryClient } from '@tanstack/react-query'
 
@@ -17,7 +18,6 @@ import { useQueryClient } from '@tanstack/react-query'
 
 const schema = z.object({
   name: z.string().min(1, 'Nome obrigatório'),
-  type: z.enum(['SIMPLE', 'TABULAR']),
 })
 
 type FormValues = z.infer<typeof schema>
@@ -39,10 +39,11 @@ export function NewCustomerSheetModal({ customerId, onClose }: NewCustomerSheetM
   const {
     register,
     handleSubmit,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, isValid },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { name: '', type: 'SIMPLE' },
+    defaultValues: { name: '' },
+    mode: 'onChange',
   })
 
   const onSubmit = handleSubmit(async (data) => {
@@ -125,10 +126,10 @@ export function NewCustomerSheetModal({ customerId, onClose }: NewCustomerSheetM
           </div>
 
           {/* Info */}
-          <div className="rounded-lg border bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
+          <InfoBanner variant="info">
             Esta ficha será criada na categoria <strong>Personalizada</strong> e ficará disponível
             apenas para este cliente.
-          </div>
+          </InfoBanner>
         </div>
 
         <div className="sticky bottom-0 bg-card border-t px-6 py-4 flex justify-end gap-2 rounded-b-xl">
@@ -141,7 +142,7 @@ export function NewCustomerSheetModal({ customerId, onClose }: NewCustomerSheetM
           >
             Cancelar
           </Button>
-          <Button type="submit" size="sm" disabled={createSheet.isPending}>
+          <Button type="submit" size="sm" disabled={createSheet.isPending || !isValid}>
             {createSheet.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
             Criar ficha
           </Button>

--- a/aesthera/apps/web/components/measurement-sheets/NewCustomerSheetModal.tsx
+++ b/aesthera/apps/web/components/measurement-sheets/NewCustomerSheetModal.tsx
@@ -1,86 +1,172 @@
 'use client'
 
-import { useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { useState, useEffect } from 'react'
 import { toast } from 'sonner'
 import { Loader2, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { InfoBanner } from '@/components/ui/info-banner'
-import { useCreateMeasurementSheet } from '@/lib/hooks/use-measurement-sheets'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import {
+  useMeasurementSheets,
+  useCreateMeasurementSheet,
+  type MeasurementSheetType,
+} from '@/lib/hooks/use-measurement-sheets'
+import {
+  CATEGORY_LABELS,
+  MEASUREMENT_CATEGORIES_ORDER,
+} from '@/lib/measurement-categories'
 import { useQueryClient } from '@tanstack/react-query'
-
-// ──── Schema ───────────────────────────────────────────────────────────────────
-
-const schema = z.object({
-  name: z.string().min(1, 'Nome obrigatório'),
-})
-
-type FormValues = z.infer<typeof schema>
 
 // ──── Props ────────────────────────────────────────────────────────────────────
 
 interface NewCustomerSheetModalProps {
   customerId: string
   onClose: () => void
+  onCreated: (sheetId: string, sheetType: MeasurementSheetType) => void
 }
 
 // ──── Component ────────────────────────────────────────────────────────────────
 
-export function NewCustomerSheetModal({ customerId, onClose }: NewCustomerSheetModalProps) {
+export function NewCustomerSheetModal({ customerId, onClose, onCreated }: NewCustomerSheetModalProps) {
   const qc = useQueryClient()
   const createSheet = useCreateMeasurementSheet()
-  const [selectedType, setSelectedType] = useState<'SIMPLE' | 'TABULAR'>('SIMPLE')
 
-  const {
-    register,
-    handleSubmit,
-    formState: { errors, isDirty, isValid },
-  } = useForm<FormValues>({
-    resolver: zodResolver(schema),
-    defaultValues: { name: '' },
-    mode: 'onChange',
-  })
+  const [mode, setMode] = useState<'blank' | 'from-sheet'>('from-sheet')
+  const [name, setName] = useState('')
+  const [nameError, setNameError] = useState('')
+  const [selectedType, setSelectedType] = useState<MeasurementSheetType>('SIMPLE')
+  const [selectedSystemSheetId, setSelectedSystemSheetId] = useState<string>('')
 
-  const onSubmit = handleSubmit(async (data) => {
+  const { data: systemSheets = [] } = useMeasurementSheets({ scope: 'SYSTEM' })
+  const activeSystemSheets = systemSheets.filter((s) => s.active)
+
+  // Pré-preencher nome ao selecionar ficha do sistema
+  useEffect(() => {
+    if (mode === 'from-sheet' && selectedSystemSheetId) {
+      const sheet = activeSystemSheets.find((s) => s.id === selectedSystemSheetId)
+      if (sheet) {
+        setName(`${sheet.name} (Cliente)`)
+        setSelectedType(sheet.type)
+      }
+    }
+  }, [selectedSystemSheetId, mode]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim()) { setNameError('Nome obrigatório'); return }
+    if (mode === 'from-sheet' && !selectedSystemSheetId) { setNameError('Selecione uma ficha base'); return }
+
     try {
-      await createSheet.mutateAsync({
-        name: data.name,
+      const sheet = await createSheet.mutateAsync({
+        name: name.trim(),
         type: selectedType,
         category: 'PERSONALIZADA',
         scope: 'CUSTOMER',
         customerId,
+        ...(mode === 'from-sheet' && selectedSystemSheetId
+          ? { sourceSheetId: selectedSystemSheetId }
+          : {}),
       })
       await qc.invalidateQueries({ queryKey: ['measurement-sheets'] })
       toast.success('Ficha personalizada criada com sucesso')
-      onClose()
+      onCreated(sheet.id, sheet.type)
     } catch {
       toast.error('Erro ao criar ficha personalizada')
     }
-  })
+  }
 
   return (
-    <Dialog open onClose={onClose} isDirty={isDirty} className="max-w-md p-0">
+    <Dialog open onClose={onClose} isDirty={name.length > 0} className="max-w-md p-0">
       <div className="sticky top-0 bg-card border-b px-6 py-4 flex items-center justify-between rounded-t-xl z-10">
         <DialogTitle className="mb-0">Nova ficha deste cliente</DialogTitle>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          onClick={onClose}
-          className="h-7 w-7 text-muted-foreground"
-          aria-label="Fechar modal"
-        >
+        <Button type="button" variant="ghost" size="icon" onClick={onClose} className="h-7 w-7 text-muted-foreground" aria-label="Fechar modal">
           <X className="h-4 w-4" />
         </Button>
       </div>
 
-      <form onSubmit={onSubmit}>
+      <form onSubmit={handleSubmit}>
         <div className="p-6 space-y-5">
+          {/* Modo */}
+          <div className="space-y-2">
+            <Label>Ponto de partida</Label>
+            <div className="grid grid-cols-2 gap-2">
+              {(['from-sheet', 'blank'] as const).map((m) => (
+                <Button
+                  key={m}
+                  type="button"
+                  variant="ghost"
+                  onClick={() => { setMode(m); setSelectedSystemSheetId(''); setName(''); setNameError('') }}
+                  className={[
+                    'h-auto flex-col items-start whitespace-normal rounded-lg border p-3 text-left',
+                    mode === m ? 'border-primary bg-primary/5 ring-1 ring-primary' : 'border-border hover:bg-muted/40',
+                  ].join(' ')}
+                >
+                  <p className="text-sm font-medium">{m === 'from-sheet' ? 'Baseada em ficha do sistema' : 'Em branco'}</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {m === 'from-sheet' ? 'Copia campos de uma ficha existente' : 'Cria do zero, você define os campos'}
+                  </p>
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          {/* Ficha do sistema (modo from-sheet) */}
+          {mode === 'from-sheet' && (
+            <div className="space-y-1.5">
+              <Label>Ficha base</Label>
+              <Select value={selectedSystemSheetId} onValueChange={setSelectedSystemSheetId}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Selecione uma ficha do sistema…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {MEASUREMENT_CATEGORIES_ORDER.filter((cat) => cat !== 'PERSONALIZADA').map((cat) => {
+                    const sheetsInCat = activeSystemSheets.filter((s) => s.category === cat)
+                    if (sheetsInCat.length === 0) return null
+                    return (
+                      <div key={cat}>
+                        <p className="px-2 py-1 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                          {CATEGORY_LABELS[cat]}
+                        </p>
+                        {sheetsInCat.map((s) => (
+                          <SelectItem key={s.id} value={s.id}>{s.name}</SelectItem>
+                        ))}
+                      </div>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Formato (só modo blank — no from-sheet é herdado) */}
+          {mode === 'blank' && (
+            <div className="space-y-2">
+              <Label>Formato</Label>
+              <div className="grid grid-cols-2 gap-3">
+                {([
+                  { value: 'SIMPLE' as const, label: 'Lista de campos', description: 'Campos individuais por linha' },
+                  { value: 'TABULAR' as const, label: 'Tabela', description: 'Grade de linhas × colunas' },
+                ]).map((opt) => (
+                  <Button
+                    key={opt.value}
+                    type="button"
+                    variant="ghost"
+                    onClick={() => setSelectedType(opt.value)}
+                    className={[
+                      'h-auto w-full flex-col items-start whitespace-normal rounded-lg border p-3 text-left transition-colors',
+                      selectedType === opt.value ? 'border-primary bg-primary/5 ring-1 ring-primary' : 'border-border hover:bg-muted/40',
+                    ].join(' ')}
+                  >
+                    <p className="text-sm font-medium">{opt.label}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">{opt.description}</p>
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* Nome */}
           <div className="space-y-1.5">
             <Label htmlFor="sheet-name">
@@ -89,60 +175,18 @@ export function NewCustomerSheetModal({ customerId, onClose }: NewCustomerSheetM
             <Input
               id="sheet-name"
               placeholder="Ex: Avaliação facial personalizada"
-              {...register('name')}
+              value={name}
+              onChange={(e) => { setName(e.target.value); setNameError('') }}
             />
-            {errors.name && (
-              <p className="text-xs text-destructive">{errors.name.message}</p>
-            )}
+            {nameError && <p className="text-xs text-destructive">{nameError}</p>}
           </div>
-
-          {/* Formato */}
-          <div className="space-y-2">
-            <Label>Formato</Label>
-            <div className="grid grid-cols-2 gap-3">
-              {(
-                [
-                  { value: 'SIMPLE', label: 'Lista de campos', description: 'Campos individuais por linha' },
-                  { value: 'TABULAR', label: 'Tabela', description: 'Grade de linhas × colunas' },
-                ] as const
-              ).map((opt) => (
-                <Button
-                  key={opt.value}
-                  type="button"
-                  variant="ghost"
-                  onClick={() => setSelectedType(opt.value)}
-                  className={[
-                    'h-auto w-full flex-col items-start whitespace-normal rounded-lg border p-3 text-left transition-colors',
-                    selectedType === opt.value
-                      ? 'border-primary bg-primary/5 ring-1 ring-primary'
-                      : 'border-border hover:bg-muted/40',
-                  ].join(' ')}
-                >
-                  <p className="text-sm font-medium">{opt.label}</p>
-                  <p className="text-xs text-muted-foreground mt-0.5">{opt.description}</p>
-                </Button>
-              ))}
-            </div>
-          </div>
-
-          {/* Info */}
-          <InfoBanner variant="info">
-            Esta ficha será criada na categoria <strong>Personalizada</strong> e ficará disponível
-            apenas para este cliente.
-          </InfoBanner>
         </div>
 
         <div className="sticky bottom-0 bg-card border-t px-6 py-4 flex justify-end gap-2 rounded-b-xl">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={onClose}
-            disabled={createSheet.isPending}
-          >
+          <Button type="button" variant="outline" size="sm" onClick={onClose} disabled={createSheet.isPending}>
             Cancelar
           </Button>
-          <Button type="submit" size="sm" disabled={createSheet.isPending || !isValid}>
+          <Button type="submit" size="sm" disabled={createSheet.isPending || !name.trim()}>
             {createSheet.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
             Criar ficha
           </Button>

--- a/aesthera/apps/web/components/measurement-sheets/NewCustomerSheetModal.tsx
+++ b/aesthera/apps/web/components/measurement-sheets/NewCustomerSheetModal.tsx
@@ -66,14 +66,16 @@ export function NewCustomerSheetModal({ customerId, onClose }: NewCustomerSheetM
     <Dialog open onClose={onClose} isDirty={isDirty} className="max-w-md p-0">
       <div className="sticky top-0 bg-card border-b px-6 py-4 flex items-center justify-between rounded-t-xl z-10">
         <DialogTitle className="mb-0">Nova ficha deste cliente</DialogTitle>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon"
           onClick={onClose}
-          className="text-muted-foreground hover:text-foreground"
+          className="h-7 w-7 text-muted-foreground"
           aria-label="Fechar modal"
         >
           <X className="h-4 w-4" />
-        </button>
+        </Button>
       </div>
 
       <form onSubmit={onSubmit}>
@@ -103,12 +105,13 @@ export function NewCustomerSheetModal({ customerId, onClose }: NewCustomerSheetM
                   { value: 'TABULAR', label: 'Tabela', description: 'Grade de linhas × colunas' },
                 ] as const
               ).map((opt) => (
-                <button
+                <Button
                   key={opt.value}
                   type="button"
+                  variant="ghost"
                   onClick={() => setSelectedType(opt.value)}
                   className={[
-                    'rounded-lg border p-3 text-left transition-colors',
+                    'h-auto w-full flex-col items-start whitespace-normal rounded-lg border p-3 text-left transition-colors',
                     selectedType === opt.value
                       ? 'border-primary bg-primary/5 ring-1 ring-primary'
                       : 'border-border hover:bg-muted/40',
@@ -116,7 +119,7 @@ export function NewCustomerSheetModal({ customerId, onClose }: NewCustomerSheetM
                 >
                   <p className="text-sm font-medium">{opt.label}</p>
                   <p className="text-xs text-muted-foreground mt-0.5">{opt.description}</p>
-                </button>
+                </Button>
               ))}
             </div>
           </div>

--- a/aesthera/apps/web/components/measurement-sheets/NewCustomerSheetModal.tsx
+++ b/aesthera/apps/web/components/measurement-sheets/NewCustomerSheetModal.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { toast } from 'sonner'
+import { Loader2, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useCreateMeasurementSheet } from '@/lib/hooks/use-measurement-sheets'
+import { useQueryClient } from '@tanstack/react-query'
+
+// ──── Schema ───────────────────────────────────────────────────────────────────
+
+const schema = z.object({
+  name: z.string().min(1, 'Nome obrigatório'),
+  type: z.enum(['SIMPLE', 'TABULAR']),
+})
+
+type FormValues = z.infer<typeof schema>
+
+// ──── Props ────────────────────────────────────────────────────────────────────
+
+interface NewCustomerSheetModalProps {
+  customerId: string
+  onClose: () => void
+}
+
+// ──── Component ────────────────────────────────────────────────────────────────
+
+export function NewCustomerSheetModal({ customerId, onClose }: NewCustomerSheetModalProps) {
+  const qc = useQueryClient()
+  const createSheet = useCreateMeasurementSheet()
+  const [selectedType, setSelectedType] = useState<'SIMPLE' | 'TABULAR'>('SIMPLE')
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { name: '', type: 'SIMPLE' },
+  })
+
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      await createSheet.mutateAsync({
+        name: data.name,
+        type: selectedType,
+        category: 'PERSONALIZADA',
+        scope: 'CUSTOMER',
+        customerId,
+      })
+      await qc.invalidateQueries({ queryKey: ['measurement-sheets'] })
+      toast.success('Ficha personalizada criada com sucesso')
+      onClose()
+    } catch {
+      toast.error('Erro ao criar ficha personalizada')
+    }
+  })
+
+  return (
+    <Dialog open onClose={onClose} isDirty={isDirty} className="max-w-md p-0">
+      <div className="sticky top-0 bg-card border-b px-6 py-4 flex items-center justify-between rounded-t-xl z-10">
+        <DialogTitle className="mb-0">Nova ficha deste cliente</DialogTitle>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="Fechar modal"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <form onSubmit={onSubmit}>
+        <div className="p-6 space-y-5">
+          {/* Nome */}
+          <div className="space-y-1.5">
+            <Label htmlFor="sheet-name">
+              Nome <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="sheet-name"
+              placeholder="Ex: Avaliação facial personalizada"
+              {...register('name')}
+            />
+            {errors.name && (
+              <p className="text-xs text-destructive">{errors.name.message}</p>
+            )}
+          </div>
+
+          {/* Formato */}
+          <div className="space-y-2">
+            <Label>Formato</Label>
+            <div className="grid grid-cols-2 gap-3">
+              {(
+                [
+                  { value: 'SIMPLE', label: 'Lista de campos', description: 'Campos individuais por linha' },
+                  { value: 'TABULAR', label: 'Tabela', description: 'Grade de linhas × colunas' },
+                ] as const
+              ).map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setSelectedType(opt.value)}
+                  className={[
+                    'rounded-lg border p-3 text-left transition-colors',
+                    selectedType === opt.value
+                      ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                      : 'border-border hover:bg-muted/40',
+                  ].join(' ')}
+                >
+                  <p className="text-sm font-medium">{opt.label}</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">{opt.description}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="rounded-lg border bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
+            Esta ficha será criada na categoria <strong>Personalizada</strong> e ficará disponível
+            apenas para este cliente.
+          </div>
+        </div>
+
+        <div className="sticky bottom-0 bg-card border-t px-6 py-4 flex justify-end gap-2 rounded-b-xl">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onClose}
+            disabled={createSheet.isPending}
+          >
+            Cancelar
+          </Button>
+          <Button type="submit" size="sm" disabled={createSheet.isPending}>
+            {createSheet.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+            Criar ficha
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  )
+}

--- a/aesthera/apps/web/lib/hooks/use-measurement-sessions.ts
+++ b/aesthera/apps/web/lib/hooks/use-measurement-sessions.ts
@@ -110,14 +110,14 @@ export interface UpdateSessionInput {
 
 export function useMeasurementSessions(
   customerId: string,
-  options?: { page?: number; limit?: number; enabled?: boolean },
+  options?: { page?: number; limit?: number; category?: string; enabled?: boolean },
 ) {
-  const { page = 1, limit = 20, enabled = true } = options ?? {}
+  const { page = 1, limit = 20, category, enabled = true } = options ?? {}
   return useQuery({
-    queryKey: ['measurement-sessions', customerId, { page, limit }],
+    queryKey: ['measurement-sessions', customerId, { page, limit, category }],
     queryFn: async () => {
       const res = await api.get<Paginated<MeasurementSession>>('/measurement-sessions', {
-        params: { customerId, page, limit },
+        params: { customerId, page, limit, ...(category ? { category } : {}) },
       })
       return res.data
     },

--- a/aesthera/apps/web/lib/hooks/use-measurement-sheets.ts
+++ b/aesthera/apps/web/lib/hooks/use-measurement-sheets.ts
@@ -73,6 +73,7 @@ interface CreateSheetInput {
   category?: MeasurementCategory
   scope?: MeasurementScope
   customerId?: string
+  sourceSheetId?: string
 }
 
 interface UpdateSheetInput {

--- a/aesthera/apps/web/lib/hooks/use-measurement-sheets.ts
+++ b/aesthera/apps/web/lib/hooks/use-measurement-sheets.ts
@@ -72,6 +72,7 @@ interface CreateSheetInput {
   order?: number
   category?: MeasurementCategory
   scope?: MeasurementScope
+  customerId?: string
 }
 
 interface UpdateSheetInput {
@@ -142,25 +143,29 @@ interface UseMeasurementSheetsOptions {
   includeInactive?: boolean
   scope?: MeasurementScope
   category?: MeasurementCategory
+  customerId?: string
 }
 
 export function useMeasurementSheets({
   includeInactive = false,
   scope,
   category,
+  customerId,
 }: UseMeasurementSheetsOptions = {}) {
   return useQuery({
-    queryKey: ['measurement-sheets', { includeInactive, scope, category }],
+    queryKey: ['measurement-sheets', { includeInactive, scope, category, customerId }],
     queryFn: async () => {
       const params = new URLSearchParams()
       if (includeInactive) params.set('includeInactive', 'true')
       if (scope) params.set('scope', scope)
       if (category) params.set('category', category)
+      if (customerId) params.set('customerId', customerId)
       const query = params.toString()
       const url = query ? `/measurement-sheets?${query}` : '/measurement-sheets'
       const res = await api.get<MeasurementSheet[]>(url)
       return res.data
     },
+    enabled: scope !== 'CUSTOMER' || !!customerId,
   })
 }
 

--- a/aesthera/apps/web/lib/measurement-categories.ts
+++ b/aesthera/apps/web/lib/measurement-categories.ts
@@ -59,3 +59,17 @@ export const FIELD_INPUT_TYPE_BADGE_COLOR: Record<MeasurementInputType, string> 
   INPUT: 'bg-sky-600 text-white dark:bg-sky-700',
   CHECK: 'bg-emerald-600 text-white dark:bg-emerald-700',
 }
+
+export type FieldDisplayType = 'NUMBER' | 'TEXT' | 'CHECK'
+
+export const FIELD_DISPLAY_TYPE_LABEL: Record<FieldDisplayType, string> = {
+  NUMBER: 'Número',
+  TEXT:   'Texto',
+  CHECK:  'Marcação',
+}
+
+export const FIELD_DISPLAY_TYPE_BADGE_COLOR: Record<FieldDisplayType, string> = {
+  NUMBER: 'bg-blue-600 text-white dark:bg-blue-700',
+  TEXT:   'bg-slate-500 text-white dark:bg-slate-600',
+  CHECK:  'bg-emerald-600 text-white dark:bg-emerald-700',
+}

--- a/aesthera/docs/screen-mapping.md
+++ b/aesthera/docs/screen-mapping.md
@@ -1,6 +1,6 @@
 # Mapeamento de Telas — Aesthera
 
-**Última atualização:** 14/04/2026  
+**Última atualização:** 15/04/2026  
 **Fonte original:** Relatório UX — Mapeamento de Telas (`outputs/ux/aesthera-ux-mapeamento-telas-2026-03-31.md`)
 
 ---
@@ -88,7 +88,7 @@ Todo agente que atuar em criação, alteração ou remoção de telas **deve**:
 | Carteira | Sub-abas: **Carteira** (vouchers/créditos ativos, saldo, extrato de transações) e **Pacotes** (pacotes comprados e sessões restantes) |
 | Prontuário | Lançamentos clínicos classificados por tipo: Anamnese, Exame, Observação, Procedimento, Prescrição |
 | Contratos | Contratos do cliente com status de assinatura e ações de assinar/enviar |
-| Evolução | Registros de medidas corporais nas fichas configuradas no sistema |
+| Avaliações | Histórico clínico completo com filtro por categoria (Corporal, Facial, Dermato-funcional, Nutricional, Postural, Personalizada), badges de categoria por sessão e fichas personalizadas por cliente |
 
 ---
 
@@ -395,3 +395,5 @@ Ações disponíveis: confirmar, cancelar, registrar pagamento, receber manualme
 |------|------|----------------|-------------|
 | 31/03/2026 | Todas | Criação inicial do arquivo | UX Review + Treinador |
 | 14/04/2026 | Configurações → Fichas de Avaliação | Renomeada aba "Medidas Corporais" → "Fichas de Avaliação"; redesign para layout de 3 painéis com 6 categorias, drag-and-drop e biblioteca de modelos pré-configurados | feat(#158) |
+| 15/04/2026 | Clientes → aba Avaliações | Renomeada aba "Evolução" → "Avaliações"; filtro de categoria por pills, badges de categoria por sessão, modal de seleção de fichas agrupado (Clínica / Cliente), botão "Nova ficha deste cliente" com autorização por role | feat(#159) |
+| 15/04/2026 | Clientes → aba Avaliações | Renomeada aba "Evolução" → "Avaliações"; filtro de categoria por pills, badges de categoria por sessão, modal de seleção de fichas agrupado (Clínica / Cliente), botão "Nova ficha deste cliente" com autorização por role | feat(#159) |

--- a/aesthera/docs/screen-mapping.md
+++ b/aesthera/docs/screen-mapping.md
@@ -396,4 +396,3 @@ Ações disponíveis: confirmar, cancelar, registrar pagamento, receber manualme
 | 31/03/2026 | Todas | Criação inicial do arquivo | UX Review + Treinador |
 | 14/04/2026 | Configurações → Fichas de Avaliação | Renomeada aba "Medidas Corporais" → "Fichas de Avaliação"; redesign para layout de 3 painéis com 6 categorias, drag-and-drop e biblioteca de modelos pré-configurados | feat(#158) |
 | 15/04/2026 | Clientes → aba Avaliações | Renomeada aba "Evolução" → "Avaliações"; filtro de categoria por pills, badges de categoria por sessão, modal de seleção de fichas agrupado (Clínica / Cliente), botão "Nova ficha deste cliente" com autorização por role | feat(#159) |
-| 15/04/2026 | Clientes → aba Avaliações | Renomeada aba "Evolução" → "Avaliações"; filtro de categoria por pills, badges de categoria por sessão, modal de seleção de fichas agrupado (Clínica / Cliente), botão "Nova ficha deste cliente" com autorização por role | feat(#159) |

--- a/ai-engineering/projects/aesthera/PLAN.md
+++ b/ai-engineering/projects/aesthera/PLAN.md
@@ -463,6 +463,26 @@ Corrigir dois problemas estruturais do PR #148: (1) `CompleteAppointmentModal` e
   - Todos os labels em PT-BR; nenhum enum exposto na UI
 - **Closes:** #158
 
+### [2026-04-15] — feat(#159): Fichas de Avaliação Expandidas — Frontend Cliente 3/3
+- **Módulo:** MeasurementSheets — Frontend Perfil do Cliente
+- **Issue:** [#159](https://github.com/DjoniLw/ia/issues/159) — Aba Avaliações no perfil do cliente
+- **Branch:** `feat/issue-159-fichas-avaliacao-customer-frontend`
+- **Arquivo(s) afetado(s):**
+  - `aesthera/apps/web/app/(dashboard)/customers/page.tsx` *(renomeada aba "Avaliação" → "Avaliações")*
+  - `aesthera/apps/web/components/body-measurements/evolution-tab.tsx` *(refatoração completa: filtro por categoria server-side, SessionFormModal com busca interna de fichas, badges de categoria, canCreate guard restaurado, hasUnsaved baseado em selectionDirty)*
+  - `aesthera/apps/web/components/measurement-sheets/NewCustomerSheetModal.tsx` *(NOVO — modal de criação de ficha scope=CUSTOMER, category=PERSONALIZADA, isValid guard)*
+  - `aesthera/apps/web/lib/hooks/use-measurement-sheets.ts` *(EXPANDIDO — suporte a customerId em UseMeasurementSheetsOptions, CreateSheetInput e query)*
+  - `aesthera/apps/web/lib/hooks/use-measurement-sessions.ts` *(EXPANDIDO — suporte a category no filtro)*
+  - `aesthera/apps/api/src/modules/measurement-sessions/measurement-sessions.dto.ts` *(EXPANDIDO — category opcional em ListSessionsQuery)*
+  - `aesthera/apps/api/src/modules/measurement-sessions/measurement-sessions.repository.ts` *(EXPANDIDO — filtro por category via sheetRecords.some)*
+  - `aesthera/docs/screen-mapping.md` *(aba Avaliações atualizada, duplicata removida)*
+- **Closes:** #159
+
+### [2026-04-15] — Code Review PR #162
+- **Arquivo gerado:** `outputs/code-review/pr/revisao_pr162_2026-04-15.md`
+- **O que foi feito:** Revisão do PR #162 (feat(#159): aba Avaliações no perfil do cliente e fichas personalizadas) — 5 bloqueantes, 6 sugestões
+- **Impacto:** Qualidade e integridade do código revisado; PR reprovado pendente correções
+
 ### [2026-04-09] — fix(#155): Code Review PR #155 — 6 bloqueantes e 3 sugestões corrigidos
 - **Módulo:** Anamnesis (correções pós-code-review PR #155)
 - **Arquivo(s) afetado(s):**


### PR DESCRIPTION
## Descrição

Implementação do item **3/3** do módulo de Fichas de Avaliação Expandidas — frontend da aba Avaliações no perfil do cliente.

Closes #159

---

## Mudanças

### `customers/page.tsx`
- Aba `'Avaliação'` renomeada para **`'Avaliações'`**

### `evolution-tab.tsx` (refatoração completa dos componentes internos)

**`SessionCard`**
- Substituídos os `sheetBadges` por `sessionCategories` derivados de `session.sheetRecords.map(sr => sr.sheet.category)`
- Badges exibem a cor correta via `CATEGORY_BADGE_COLOR[cat]`

**`SessionFormModal`**
- Removida a prop `sheets: MeasurementSheet[]`
- Agora busca internamente: `useMeasurementSheets({ scope: 'SYSTEM' })` + `useMeasurementSheets({ scope: 'CUSTOMER', customerId })`
- Estado `selectedSheetIds: Set<string>` para controle por checkbox
- Dois grupos: **Fichas da Clínica** e **Fichas deste Cliente**
- Skeleton por grupo durante carregamento
- Botão Salvar desabilitado quando `selectedSheetIds.size === 0`

**`SheetFormSection`**
- Novas props opcionais: `selectable`, `selected`, `onSelectionChange`
- Checkbox no cabeçalho quando `selectable=true`

**`EvolutionTab`** (componente principal)
- Removido `useMeasurementSheets()` global + `activeSheets`
- Adicionado filtro por categoria via **pills** (`Todas` + 6 categorias na ordem canônica)
- Novo empty state com ícone `ClipboardList`
- Botão **"Nova ficha deste cliente"** com lógica de autorização:
  - `professional` sem agendamento confirmado: desabilitado com tooltip
  - Limite de 10 fichas ativas atingido: desabilitado com tooltip
- `SessionFormModal` chamado sem a prop `sheets`

### `NewCustomerSheetModal.tsx` (novo arquivo)
- Localização: `components/measurement-sheets/NewCustomerSheetModal.tsx`
- Cria fichas `scope=CUSTOMER`, `category=PERSONALIZADA`
- Campos: Nome* + Formato (SIMPLE / TABULAR, seletor visual 2 cards)
- Guarda `isDirty`, toast de sucesso, invalidação de query

### `use-measurement-sheets.ts`
- `UseMeasurementSheetsOptions` recebe `customerId?: string`
- `CreateSheetInput` recebe `customerId?: string`
- Query key e params de URL incluem `customerId`
- `enabled: scope !== 'CUSTOMER' || !!customerId`

### `docs/screen-mapping.md`
- Aba `Evolução` → `Avaliações` com descrição atualizada
- Entrada no histórico de alterações

---

## Checklist

- [x] Sem texto em inglês exposto ao usuário
- [x] Sem erros de TypeScript
- [x] Padrões de pills e empty state seguem `ui-standards.md`
- [x] `screen-mapping.md` atualizado
- [x] Sem `useMeasurementSheets()` sem filtro em componente de cliente