### PR TITLE
feat: [GALERIA DE FOTOS] 1/2 — Galeria básica com upload direto, lightbox e filtros (#163)

### DIFF
--- a/aesthera/apps/api/prisma/migrations/20260421_feat_galeria_fotos_extensao_customer_file/migration.sql
+++ b/aesthera/apps/api/prisma/migrations/20260421_feat_galeria_fotos_extensao_customer_file/migration.sql
@@ -1,0 +1,31 @@
+-- Migration: feat-galeria-fotos-extensao-customer-file
+-- Issue #163 — Galeria de Fotos do Cliente (Fase 1)
+-- Não-destrutiva: apenas adiciona campos nullable e novos valores de enum
+
+-- Adicionar novos valores ao enum FileCategory
+ALTER TYPE "FileCategory" ADD VALUE IF NOT EXISTS 'PROGRESS_PHOTO';
+ALTER TYPE "FileCategory" ADD VALUE IF NOT EXISTS 'GALLERY_PHOTO';
+
+-- Adicionar novos campos à tabela customer_files
+ALTER TABLE "customer_files"
+  ADD COLUMN IF NOT EXISTS "taken_at"                     TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS "body_region"                  VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS "notes"                        TEXT,
+  ADD COLUMN IF NOT EXISTS "deleted_by_user_id"           UUID,
+  ADD COLUMN IF NOT EXISTS "deletion_reason"              TEXT,
+  ADD COLUMN IF NOT EXISTS "storage_deleted_at"           TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS "uploaded_by_professional_id"  UUID;
+
+-- FK para professionals
+ALTER TABLE "customer_files"
+  ADD CONSTRAINT "customer_files_uploaded_by_professional_id_fkey"
+  FOREIGN KEY ("uploaded_by_professional_id")
+  REFERENCES "professionals"("id")
+  ON DELETE SET NULL;
+
+-- Índices para queries da galeria
+CREATE INDEX IF NOT EXISTS "customer_files_clinic_id_customer_id_deleted_at_idx"
+  ON "customer_files"("clinic_id", "customer_id", "deleted_at");
+
+CREATE INDEX IF NOT EXISTS "customer_files_clinic_id_customer_id_taken_at_idx"
+  ON "customer_files"("clinic_id", "customer_id", "taken_at");

--- a/aesthera/apps/api/prisma/migrations/20260421_feat_galeria_fotos_extensao_customer_file/migration.sql
+++ b/aesthera/apps/api/prisma/migrations/20260421_feat_galeria_fotos_extensao_customer_file/migration.sql
@@ -11,10 +11,10 @@ ALTER TABLE "customer_files"
   ADD COLUMN IF NOT EXISTS "taken_at"                     TIMESTAMPTZ,
   ADD COLUMN IF NOT EXISTS "body_region"                  VARCHAR(100),
   ADD COLUMN IF NOT EXISTS "notes"                        TEXT,
-  ADD COLUMN IF NOT EXISTS "deleted_by_user_id"           UUID,
+  ADD COLUMN IF NOT EXISTS "deleted_by_user_id"           TEXT,
   ADD COLUMN IF NOT EXISTS "deletion_reason"              TEXT,
   ADD COLUMN IF NOT EXISTS "storage_deleted_at"           TIMESTAMPTZ,
-  ADD COLUMN IF NOT EXISTS "uploaded_by_professional_id"  UUID;
+  ADD COLUMN IF NOT EXISTS "uploaded_by_professional_id"  TEXT;
 
 -- FK para professionals
 ALTER TABLE "customer_files"

--- a/aesthera/apps/api/prisma/schema.prisma
+++ b/aesthera/apps/api/prisma/schema.prisma
@@ -157,6 +157,8 @@ enum NotificationType {
 enum FileCategory {
   BEFORE_PHOTO
   AFTER_PHOTO
+  PROGRESS_PHOTO
+  GALLERY_PHOTO
   MEASUREMENT
   EXAM
   OTHER
@@ -454,6 +456,7 @@ model Professional {
   appointments    Appointment[]
   blockedSlots    BlockedSlot[]
   clinicalRecords ClinicalRecord[]
+  uploadedPhotos  CustomerFile[]            @relation("PhotoUploadedByProfessional")
 
   @@unique([clinicId, email])
   @@index([clinicId])
@@ -1327,29 +1330,40 @@ model ManualReceiptLine {
 // Soft-delete via deletedAt — NUNCA hard-delete.
 
 model CustomerFile {
-  id                   String           @id @default(uuid())
-  clinicId             String           @map("clinic_id")
-  customerId           String           @map("customer_id")
-  recordId             String?          @map("record_id") // FK → BodyMeasurementRecord (legado)
-  measurementSessionId String?          @map("measurement_session_id") // FK → MeasurementSession (novo)
-  name                 String
-  mimeType             String           @map("mime_type")
-  size                 Int
-  storageKey           String           @unique @map("storage_key")
-  category             FileCategory
-  status               FileUploadStatus @default(CONFIRMED)
-  deletedAt            DateTime?        @map("deleted_at") // soft-delete — NUNCA Boolean deleted
-  uploadedAt           DateTime         @default(now()) @map("uploaded_at")
-  uploadedById         String           @map("uploaded_by_id") // FK → User (rastreabilidade)
+  id                       String           @id @default(uuid())
+  clinicId                 String           @map("clinic_id")
+  customerId               String           @map("customer_id")
+  recordId                 String?          @map("record_id") // FK → BodyMeasurementRecord (legado)
+  measurementSessionId     String?          @map("measurement_session_id") // FK → MeasurementSession (novo)
+  name                     String
+  mimeType                 String           @map("mime_type")
+  size                     Int
+  storageKey               String           @unique @map("storage_key")
+  category                 FileCategory
+  status                   FileUploadStatus @default(CONFIRMED)
+  deletedAt                DateTime?        @map("deleted_at") // soft-delete — NUNCA Boolean deleted
+  uploadedAt               DateTime         @default(now()) @map("uploaded_at")
+  uploadedById             String           @map("uploaded_by_id") // FK → User (rastreabilidade)
+  // Campos da galeria de fotos (Fase 1 — Issue #163)
+  takenAt                  DateTime?        @map("taken_at")
+  bodyRegion               String?          @map("body_region") // max 100 chars
+  notes                    String?          // max 500 chars
+  deletedByUserId          String?          @map("deleted_by_user_id")
+  deletionReason           String?          @map("deletion_reason")
+  storageDeletedAt         DateTime?        @map("storage_deleted_at")
+  uploadedByProfessionalId String?          @map("uploaded_by_professional_id")
 
-  clinic             Clinic                 @relation(fields: [clinicId], references: [id], onDelete: Restrict)
-  customer           Customer               @relation(fields: [customerId], references: [id], onDelete: Restrict)
-  record             BodyMeasurementRecord? @relation(fields: [recordId], references: [id], onDelete: SetNull)
-  measurementSession MeasurementSession?    @relation(fields: [measurementSessionId], references: [id], onDelete: SetNull)
+  clinic                 Clinic                 @relation(fields: [clinicId], references: [id], onDelete: Restrict)
+  customer               Customer               @relation(fields: [customerId], references: [id], onDelete: Restrict)
+  record                 BodyMeasurementRecord? @relation(fields: [recordId], references: [id], onDelete: SetNull)
+  measurementSession     MeasurementSession?    @relation(fields: [measurementSessionId], references: [id], onDelete: SetNull)
+  uploadedByProfessional Professional?          @relation("PhotoUploadedByProfessional", fields: [uploadedByProfessionalId], references: [id], onDelete: SetNull)
 
   @@index([clinicId, customerId])
   @@index([clinicId, recordId])
   @@index([clinicId, measurementSessionId])
+  @@index([clinicId, customerId, deletedAt])
+  @@index([clinicId, customerId, takenAt])
   @@map("customer_files")
 }
 

--- a/aesthera/apps/api/src/app.ts
+++ b/aesthera/apps/api/src/app.ts
@@ -36,6 +36,7 @@ import { measurementSheetsRoutes } from './modules/measurement-sheets/measuremen
 import { measurementSessionsRoutes } from './modules/measurement-sessions/measurement-sessions.routes'
 import { contractsRoutes } from './modules/contracts/contracts.routes'
 import { anamnesisRoutes } from './modules/anamnesis/anamnesis.routes'
+import { customerPhotosRoutes } from './modules/customer-photos/customer-photos.controller'
 import { PUBLIC_ROUTES } from './shared/constants/public-routes'
 import './domain-event-handlers'
 
@@ -155,6 +156,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await measurementSessionsRoutes(app)
   await contractsRoutes(app)
   await anamnesisRoutes(app)
+  await customerPhotosRoutes(app)
 
   return app
 }

--- a/aesthera/apps/api/src/integrations/r2/r2.service.ts
+++ b/aesthera/apps/api/src/integrations/r2/r2.service.ts
@@ -34,6 +34,9 @@ function getR2Client(): S3Client {
       region: 'auto',
       endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
       credentials: { accessKeyId, secretAccessKey },
+      // Desabilita checksum automático CRC32 do SDK v3 — simplifica CORS em uploads diretos (browser → R2)
+      requestChecksumCalculation: 'WHEN_REQUIRED',
+      responseChecksumValidation: 'WHEN_REQUIRED',
     })
   }
   return _r2Client

--- a/aesthera/apps/api/src/integrations/r2/r2.service.ts
+++ b/aesthera/apps/api/src/integrations/r2/r2.service.ts
@@ -2,6 +2,7 @@ import {
   S3Client,
   HeadObjectCommand,
   GetObjectCommand,
+  DeleteObjectCommand,
 } from '@aws-sdk/client-s3'
 import { PutObjectCommand } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
@@ -148,4 +149,12 @@ export async function getObjectBuffer(storageKey: string): Promise<Buffer> {
     chunks.push(chunk)
   }
   return Buffer.concat(chunks)
+}
+
+/**
+ * Remove um objeto do R2 (job de limpeza de storage após soft-delete).
+ */
+export async function deleteObject(storageKey: string): Promise<void> {
+  const cmd = new DeleteObjectCommand({ Bucket: bucketName, Key: storageKey })
+  await getR2Client().send(cmd)
 }

--- a/aesthera/apps/api/src/modules/customer-photos/customer-photos.controller.ts
+++ b/aesthera/apps/api/src/modules/customer-photos/customer-photos.controller.ts
@@ -170,7 +170,7 @@ export async function customerPhotosRoutes(app: FastifyInstance) {
    */
   app.get(
     '/settings/photo-body-regions',
-    { preHandler: [jwtClinicGuard, roleGuard(['admin', 'staff'])] },
+    { preHandler: [jwtClinicGuard, roleGuard(['admin', 'staff', 'professional'])] },
     async (req, reply) => {
       const regions = await svc.getBodyRegions(req.clinicId)
       return reply.send({ regions })

--- a/aesthera/apps/api/src/modules/customer-photos/customer-photos.controller.ts
+++ b/aesthera/apps/api/src/modules/customer-photos/customer-photos.controller.ts
@@ -1,0 +1,194 @@
+import type { FastifyInstance } from 'fastify'
+import { jwtClinicGuard } from '../../shared/guards/jwt-clinic.guard'
+import { professionalCustomerAccessGuard } from '../../shared/guards/professional-customer-access.guard'
+import { roleGuard } from '../../shared/guards/role.guard'
+import {
+  CreatePhotosDto,
+  DeletePhotoDto,
+  ListPhotosQueryDto,
+  RequestUploadUrlDto,
+  UpdateBodyRegionsDto,
+} from './customer-photos.dto'
+import { CustomerPhotosService } from './customer-photos.service'
+
+export async function customerPhotosRoutes(app: FastifyInstance) {
+  const svc = new CustomerPhotosService()
+
+  /**
+   * POST /customers/:customerId/photos/upload-url
+   * Guard: admin, staff, professional (com verificação de agendamento elegível)
+   * Rate limit: 20 req / 10 min por userId
+   * Gera presigned PUT URLs + cache Redis anti-IDOR.
+   */
+  app.post(
+    '/customers/:customerId/photos/upload-url',
+    {
+      preHandler: [
+        jwtClinicGuard,
+        roleGuard(['admin', 'staff', 'professional']),
+        professionalCustomerAccessGuard,
+      ],
+      config: { rateLimit: { max: 20, timeWindow: '10 minutes' } },
+    },
+    async (req, reply) => {
+      const { customerId } = req.params as { customerId: string }
+      const dto = RequestUploadUrlDto.parse(req.body)
+      const result = await svc.requestUploadUrls({
+        clinicId: req.clinicId,
+        customerId,
+        userId: req.user.sub,
+        dto,
+        ip: req.ip,
+      })
+      return reply.status(200).send(result)
+    },
+  )
+
+  /**
+   * POST /customers/:customerId/photos
+   * Guard: admin, staff, professional (com verificação de agendamento elegível)
+   * Confirma fotos após upload direto ao storage — valida Redis anti-IDOR.
+   */
+  app.post(
+    '/customers/:customerId/photos',
+    {
+      preHandler: [
+        jwtClinicGuard,
+        roleGuard(['admin', 'staff', 'professional']),
+        professionalCustomerAccessGuard,
+      ],
+    },
+    async (req, reply) => {
+      const { customerId } = req.params as { customerId: string }
+      const dto = CreatePhotosDto.parse(req.body)
+      const professionalId =
+        req.user.role === 'professional' ? req.user.sub : undefined
+      const result = await svc.createPhotos({
+        clinicId: req.clinicId,
+        customerId,
+        userId: req.user.sub,
+        professionalId,
+        dto,
+        ip: req.ip,
+      })
+      return reply.status(201).send(result)
+    },
+  )
+
+  /**
+   * GET /customers/:customerId/photos
+   * Guard: admin, staff, professional (com verificação de agendamento elegível)
+   * Lista fotos paginadas com filtros; gera presigned GET URLs + log de auditoria.
+   */
+  app.get(
+    '/customers/:customerId/photos',
+    {
+      preHandler: [
+        jwtClinicGuard,
+        roleGuard(['admin', 'staff', 'professional']),
+        professionalCustomerAccessGuard,
+      ],
+    },
+    async (req, reply) => {
+      const { customerId } = req.params as { customerId: string }
+      const query = ListPhotosQueryDto.parse(req.query)
+      const result = await svc.listPhotos({
+        clinicId: req.clinicId,
+        customerId,
+        userId: req.user.sub,
+        query,
+        ip: req.ip,
+      })
+      return reply.send(result)
+    },
+  )
+
+  /**
+   * GET /customers/:customerId/photos/:photoId/url
+   * Guard: admin, staff, professional (com verificação de agendamento elegível)
+   * Revalida permissões e gera nova presigned URL para foto individual.
+   */
+  app.get(
+    '/customers/:customerId/photos/:photoId/url',
+    {
+      preHandler: [
+        jwtClinicGuard,
+        roleGuard(['admin', 'staff', 'professional']),
+        professionalCustomerAccessGuard,
+      ],
+    },
+    async (req, reply) => {
+      const { customerId, photoId } = req.params as {
+        customerId: string
+        photoId: string
+      }
+      const result = await svc.getPhotoUrl({
+        clinicId: req.clinicId,
+        customerId,
+        photoId,
+        userId: req.user.sub,
+        ip: req.ip,
+      })
+      return reply.send(result)
+    },
+  )
+
+  /**
+   * DELETE /customers/:customerId/photos/:photoId
+   * Guard: admin only
+   * Soft delete com justificativa obrigatória (mín. 10 chars).
+   */
+  app.delete(
+    '/customers/:customerId/photos/:photoId',
+    {
+      preHandler: [jwtClinicGuard, roleGuard(['admin'])],
+    },
+    async (req, reply) => {
+      const { customerId, photoId } = req.params as {
+        customerId: string
+        photoId: string
+      }
+      const dto = DeletePhotoDto.parse(req.body)
+      const result = await svc.deletePhoto({
+        clinicId: req.clinicId,
+        customerId,
+        photoId,
+        userId: req.user.sub,
+        dto,
+        ip: req.ip,
+      })
+      return reply.send(result)
+    },
+  )
+
+  // ── Settings: regiões corporais ───────────────────────────────────────────
+
+  /**
+   * GET /settings/photo-body-regions
+   * Guard: admin, staff
+   * Retorna lista de regiões corporais configuradas pela clínica.
+   */
+  app.get(
+    '/settings/photo-body-regions',
+    { preHandler: [jwtClinicGuard, roleGuard(['admin', 'staff'])] },
+    async (req, reply) => {
+      const regions = await svc.getBodyRegions(req.clinicId)
+      return reply.send({ regions })
+    },
+  )
+
+  /**
+   * PATCH /settings/photo-body-regions
+   * Guard: admin only
+   * Atualiza lista de regiões corporais (máx. 30).
+   */
+  app.patch(
+    '/settings/photo-body-regions',
+    { preHandler: [jwtClinicGuard, roleGuard(['admin'])] },
+    async (req, reply) => {
+      const dto = UpdateBodyRegionsDto.parse(req.body)
+      const regions = await svc.updateBodyRegions(req.clinicId, dto.regions)
+      return reply.send({ regions })
+    },
+  )
+}

--- a/aesthera/apps/api/src/modules/customer-photos/customer-photos.dto.ts
+++ b/aesthera/apps/api/src/modules/customer-photos/customer-photos.dto.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod'
+
+// ─── Constantes ──────────────────────────────────────────────────────────────
+
+export const PHOTO_CATEGORIES = [
+  'BEFORE_PHOTO',
+  'AFTER_PHOTO',
+  'PROGRESS_PHOTO',
+  'GALLERY_PHOTO',
+] as const
+export type PhotoCategory = (typeof PHOTO_CATEGORIES)[number]
+
+export const ALLOWED_PHOTO_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const
+
+export const MAX_PHOTO_SIZE_BYTES = 20 * 1024 * 1024 // 20 MB
+export const MAX_PHOTOS_PER_REQUEST = 5
+export const PHOTO_UPLOAD_URL_TTL_SECONDS = 3600
+export const PHOTO_UPLOAD_RATE_LIMIT = { max: 20, window: '10m' } as const
+export const MAX_BODY_REGIONS = 30
+
+// ─── Validador de data válida ─────────────────────────────────────────────────
+
+const isoDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Formato de data inválido (YYYY-MM-DD)')
+  .refine((v) => Number.isFinite(Date.parse(v)), 'Data inválida')
+
+// ─── POST /customers/:customerId/photos/upload-url ───────────────────────────
+
+export const RequestUploadUrlItemDto = z.object({
+  filename: z
+    .string()
+    .min(1)
+    .max(255)
+    .regex(/\.(jpe?g|png|webp)$/i, 'Formato não suportado. Envie JPEG, PNG ou WebP'),
+  mimeType: z.enum(ALLOWED_PHOTO_MIME_TYPES, {
+    errorMap: () => ({
+      message: 'Formato não suportado. Envie JPEG, PNG ou WebP',
+    }),
+  }),
+  sizeBytes: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_PHOTO_SIZE_BYTES, 'Arquivo excede o limite de 20 MB'),
+})
+export type RequestUploadUrlItemDto = z.infer<typeof RequestUploadUrlItemDto>
+
+export const RequestUploadUrlDto = z.object({
+  files: z
+    .array(RequestUploadUrlItemDto)
+    .min(1)
+    .max(MAX_PHOTOS_PER_REQUEST, `Selecione no máximo ${MAX_PHOTOS_PER_REQUEST} fotos por vez`),
+})
+export type RequestUploadUrlDto = z.infer<typeof RequestUploadUrlDto>
+
+// ─── POST /customers/:customerId/photos ──────────────────────────────────────
+
+export const CreatePhotoDto = z.object({
+  storageKey: z.string().min(1),
+  category: z.enum(PHOTO_CATEGORIES),
+  takenAt: isoDateSchema
+    .refine(
+      (v) => new Date(v) <= new Date(),
+      'A data da foto não pode ser no futuro',
+    )
+    .optional(),
+  bodyRegion: z.string().max(100).optional(),
+  notes: z.string().max(500).optional(),
+  sessionId: z.string().uuid().optional(),
+})
+export type CreatePhotoDto = z.infer<typeof CreatePhotoDto>
+
+export const CreatePhotosDto = z.object({
+  photos: z
+    .array(CreatePhotoDto)
+    .min(1)
+    .max(MAX_PHOTOS_PER_REQUEST, `Selecione no máximo ${MAX_PHOTOS_PER_REQUEST} fotos por vez`),
+})
+export type CreatePhotosDto = z.infer<typeof CreatePhotosDto>
+
+// ─── GET /customers/:customerId/photos ───────────────────────────────────────
+
+export const ListPhotosQueryDto = z.object({
+  category: z.enum(PHOTO_CATEGORIES).optional(),
+  bodyRegion: z.string().max(100).optional(),
+  takenAtFrom: isoDateSchema.optional(),
+  takenAtTo: isoDateSchema.optional(),
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(24),
+})
+export type ListPhotosQueryDto = z.infer<typeof ListPhotosQueryDto>
+
+// ─── DELETE /customers/:customerId/photos/:photoId ───────────────────────────
+
+export const DeletePhotoDto = z.object({
+  reason: z
+    .string()
+    .min(10, 'Justificativa deve ter no mínimo 10 caracteres')
+    .max(500),
+})
+export type DeletePhotoDto = z.infer<typeof DeletePhotoDto>
+
+// ─── PATCH /settings/photo-body-regions ──────────────────────────────────────
+
+export const UpdateBodyRegionsDto = z.object({
+  regions: z
+    .array(z.string().min(1).max(100))
+    .min(0)
+    .max(MAX_BODY_REGIONS, `Máximo de ${MAX_BODY_REGIONS} regiões corporais`),
+})
+export type UpdateBodyRegionsDto = z.infer<typeof UpdateBodyRegionsDto>

--- a/aesthera/apps/api/src/modules/customer-photos/customer-photos.repository.ts
+++ b/aesthera/apps/api/src/modules/customer-photos/customer-photos.repository.ts
@@ -1,0 +1,213 @@
+import { prisma } from '../../database/prisma/client'
+import type { ListPhotosQueryDto, PhotoCategory } from './customer-photos.dto'
+
+const PHOTO_SELECT = {
+  id: true,
+  clinicId: true,
+  customerId: true,
+  measurementSessionId: true,
+  name: true,
+  mimeType: true,
+  size: true,
+  storageKey: true,
+  category: true,
+  takenAt: true,
+  bodyRegion: true,
+  notes: true,
+  uploadedAt: true,
+  uploadedById: true,
+  uploadedByProfessionalId: true,
+  deletedAt: true,
+  uploadedByProfessional: {
+    select: { id: true, name: true },
+  },
+} as const
+
+// ─── Galeria ─────────────────────────────────────────────────────────────────
+
+export class CustomerPhotosRepository {
+  async findCustomerInClinic(customerId: string, clinicId: string) {
+    return prisma.customer.findFirst({
+      where: { id: customerId, clinicId, deletedAt: null },
+      select: {
+        id: true,
+        clinicId: true,
+        bodyDataConsentAt: true,
+      },
+    })
+  }
+
+  async findSessionInClinic(sessionId: string, clinicId: string, customerId: string) {
+    return prisma.measurementSession.findFirst({
+      where: { id: sessionId, clinicId, customerId },
+      select: { id: true },
+    })
+  }
+
+  async createPending(params: {
+    clinicId: string
+    customerId: string
+    storageKey: string
+    name: string
+    mimeType: string
+    size: number
+    category: PhotoCategory
+    uploadedById: string
+    uploadedByProfessionalId?: string
+    takenAt?: Date
+    bodyRegion?: string
+    notes?: string
+    measurementSessionId?: string
+  }) {
+    return prisma.customerFile.create({
+      data: {
+        clinicId: params.clinicId,
+        customerId: params.customerId,
+        storageKey: params.storageKey,
+        name: params.name,
+        mimeType: params.mimeType,
+        size: params.size,
+        category: params.category,
+        status: 'CONFIRMED',
+        uploadedById: params.uploadedById,
+        uploadedByProfessionalId: params.uploadedByProfessionalId ?? null,
+        takenAt: params.takenAt ?? null,
+        bodyRegion: params.bodyRegion ?? null,
+        notes: params.notes ?? null,
+        measurementSessionId: params.measurementSessionId ?? null,
+      },
+      select: PHOTO_SELECT,
+    })
+  }
+
+  async findMany(clinicId: string, customerId: string, query: ListPhotosQueryDto) {
+    const {
+      category,
+      bodyRegion,
+      takenAtFrom,
+      takenAtTo,
+      page,
+      limit,
+    } = query
+
+    const categories: PhotoCategory[] = category
+      ? [category]
+      : ['BEFORE_PHOTO', 'AFTER_PHOTO', 'PROGRESS_PHOTO', 'GALLERY_PHOTO']
+
+    const [items, total] = await prisma.$transaction([
+      prisma.customerFile.findMany({
+        where: {
+          customer: { clinicId },
+          customerId,
+          category: { in: categories },
+          deletedAt: null,
+          ...(bodyRegion && { bodyRegion }),
+          ...(takenAtFrom || takenAtTo
+            ? {
+                takenAt: {
+                  ...(takenAtFrom && { gte: new Date(takenAtFrom) }),
+                  ...(takenAtTo && { lte: new Date(takenAtTo + 'T23:59:59.999Z') }),
+                },
+              }
+            : {}),
+        },
+        orderBy: [{ takenAt: 'desc' }, { uploadedAt: 'desc' }],
+        skip: (page - 1) * limit,
+        take: limit,
+        select: PHOTO_SELECT,
+      }),
+      prisma.customerFile.count({
+        where: {
+          customer: { clinicId },
+          customerId,
+          category: { in: categories },
+          deletedAt: null,
+          ...(bodyRegion && { bodyRegion }),
+          ...(takenAtFrom || takenAtTo
+            ? {
+                takenAt: {
+                  ...(takenAtFrom && { gte: new Date(takenAtFrom) }),
+                  ...(takenAtTo && { lte: new Date(takenAtTo + 'T23:59:59.999Z') }),
+                },
+              }
+            : {}),
+        },
+      }),
+    ])
+
+    return { items, total, page, limit }
+  }
+
+  async findById(id: string, clinicId: string, customerId: string) {
+    return prisma.customerFile.findFirst({
+      where: { id, customerId, customer: { clinicId }, deletedAt: null },
+      select: PHOTO_SELECT,
+    })
+  }
+
+  async softDelete(
+    id: string,
+    clinicId: string,
+    customerId: string,
+    deletedByUserId: string,
+    deletionReason: string,
+  ) {
+    const result = await prisma.customerFile.updateMany({
+      where: { id, customerId, customer: { clinicId }, deletedAt: null },
+      data: {
+        deletedAt: new Date(),
+        deletedByUserId,
+        deletionReason,
+      },
+    })
+    if (result.count === 0) return null
+    return prisma.customerFile.findFirst({
+      where: { id },
+      select: { id: true, deletedAt: true },
+    })
+  }
+
+  // ── Job de limpeza do storage ─────────────────────────────────────────────
+
+  async findPendingStorageDeletion(batchSize = 100) {
+    const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)
+    return prisma.customerFile.findMany({
+      where: {
+        deletedAt: { lt: cutoff },
+        storageDeletedAt: null,
+      },
+      select: {
+        id: true,
+        clinicId: true,
+        storageKey: true,
+      },
+      orderBy: { clinicId: 'asc' },
+      take: batchSize,
+    })
+  }
+
+  async markStorageDeleted(ids: string[]) {
+    return prisma.customerFile.updateMany({
+      where: { id: { in: ids } },
+      data: { storageDeletedAt: new Date() },
+    })
+  }
+
+  // ── Settings da clínica ───────────────────────────────────────────────────
+
+  async findClinicSettings(clinicId: string) {
+    return prisma.clinic.findFirst({
+      where: { id: clinicId },
+      select: { id: true, settings: true },
+    })
+  }
+
+  async updateClinicSettings(clinicId: string, patch: Record<string, unknown>) {
+    const clinic = await this.findClinicSettings(clinicId)
+    const current = (clinic?.settings as Record<string, unknown> | null) ?? {}
+    await prisma.clinic.updateMany({
+      where: { id: clinicId },
+      data: { settings: { ...current, ...patch } },
+    })
+  }
+}

--- a/aesthera/apps/api/src/modules/customer-photos/customer-photos.repository.ts
+++ b/aesthera/apps/api/src/modules/customer-photos/customer-photos.repository.ts
@@ -207,7 +207,7 @@ export class CustomerPhotosRepository {
     const current = (clinic?.settings as Record<string, unknown> | null) ?? {}
     await prisma.clinic.updateMany({
       where: { id: clinicId },
-      data: { settings: { ...current, ...patch } },
+      data: { settings: { ...current, ...patch } as object },
     })
   }
 }

--- a/aesthera/apps/api/src/modules/customer-photos/customer-photos.service.test.ts
+++ b/aesthera/apps/api/src/modules/customer-photos/customer-photos.service.test.ts
@@ -98,7 +98,7 @@ describe('CustomerPhotosService', () => {
 
   describe('requestUploadUrls', () => {
     const baseDto = {
-      files: [{ filename: 'foto.jpg', mimeType: 'image/jpeg', sizeBytes: 500_000 }],
+      files: [{ filename: 'foto.jpg', mimeType: 'image/jpeg' as const, sizeBytes: 500_000 }],
     }
 
     it('deve retornar upload URLs quando cliente tem consentimento LGPD', async () => {

--- a/aesthera/apps/api/src/modules/customer-photos/customer-photos.service.test.ts
+++ b/aesthera/apps/api/src/modules/customer-photos/customer-photos.service.test.ts
@@ -98,7 +98,7 @@ describe('CustomerPhotosService', () => {
 
   describe('requestUploadUrls', () => {
     const baseDto = {
-      files: [{ filename: 'foto.jpg', mimeType: 'image/jpeg', size: 500_000 }],
+      files: [{ filename: 'foto.jpg', mimeType: 'image/jpeg', sizeBytes: 500_000 }],
     }
 
     it('deve retornar upload URLs quando cliente tem consentimento LGPD', async () => {

--- a/aesthera/apps/api/src/modules/customer-photos/customer-photos.service.test.ts
+++ b/aesthera/apps/api/src/modules/customer-photos/customer-photos.service.test.ts
@@ -1,0 +1,326 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockRepo = vi.hoisted(() => ({
+  findCustomerInClinic: vi.fn(),
+  findSessionInClinic: vi.fn(),
+  createPending: vi.fn(),
+  findMany: vi.fn(),
+  findById: vi.fn(),
+  softDelete: vi.fn(),
+  findClinicSettings: vi.fn(),
+  updateClinicSettings: vi.fn(),
+  findPendingStorageDeletion: vi.fn(),
+  markStorageDeleted: vi.fn(),
+}))
+
+const mockRedis = vi.hoisted(() => ({
+  set: vi.fn().mockResolvedValue('OK'),
+  get: vi.fn(),
+  del: vi.fn().mockResolvedValue(1),
+}))
+
+const mockGeneratePresignedPutUrl = vi.hoisted(() => vi.fn())
+const mockGeneratePresignedGetUrl = vi.hoisted(() => vi.fn())
+const mockDeleteObject = vi.hoisted(() => vi.fn())
+
+const mockCreateAuditLog = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+
+vi.mock('./customer-photos.repository', () => ({
+  CustomerPhotosRepository: vi.fn(function CustomerPhotosRepository() {
+    return mockRepo
+  }),
+}))
+
+vi.mock('../../database/redis/client', () => ({
+  redis: mockRedis,
+}))
+
+vi.mock('../../integrations/r2/r2.service', () => ({
+  generatePresignedPutUrl: mockGeneratePresignedPutUrl,
+  generatePresignedGetUrl: mockGeneratePresignedGetUrl,
+  deleteObject: mockDeleteObject,
+}))
+
+vi.mock('../../shared/audit', () => ({
+  createAuditLog: mockCreateAuditLog,
+}))
+
+import { CustomerPhotosService } from './customer-photos.service'
+import { ForbiddenError, NotFoundError, ValidationError } from '../../shared/errors/app-error'
+
+// ── Constantes ──────────────────────────────────────────────────────────────────
+
+const CLINIC_ID = 'clinic-uuid-1'
+const USER_ID = 'user-uuid-1'
+const CUSTOMER_ID = 'customer-uuid-1'
+const PHOTO_ID = 'photo-uuid-1'
+const SESSION_ID = 'session-uuid-1'
+const STORAGE_KEY = `${CLINIC_ID}/${CUSTOMER_ID}/photo-uuid.jpg`
+
+const CUSTOMER_WITH_CONSENT = {
+  id: CUSTOMER_ID,
+  bodyDataConsentAt: new Date('2024-01-01'),
+}
+
+const CUSTOMER_NO_CONSENT = {
+  id: CUSTOMER_ID,
+  bodyDataConsentAt: null,
+}
+
+const PHOTO_RECORD = {
+  id: PHOTO_ID,
+  storageKey: STORAGE_KEY,
+  category: 'BEFORE_PHOTO',
+  takenAt: null,
+  bodyRegion: null,
+  notes: null,
+  measurementSessionId: null,
+  uploadedByProfessional: null,
+}
+
+// ── Testes ──────────────────────────────────────────────────────────────────────
+
+describe('CustomerPhotosService', () => {
+  let service: CustomerPhotosService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new CustomerPhotosService()
+    // Padrão: clinica com settings sem regiões configuradas
+    mockRepo.findClinicSettings.mockResolvedValue({ id: CLINIC_ID, settings: {} })
+    mockGeneratePresignedPutUrl.mockResolvedValue('https://r2.example.com/upload-url')
+    mockGeneratePresignedGetUrl.mockResolvedValue('https://r2.example.com/get-url')
+  })
+
+  // ── requestUploadUrls ─────────────────────────────────────────────────────
+
+  describe('requestUploadUrls', () => {
+    const baseDto = {
+      files: [{ filename: 'foto.jpg', mimeType: 'image/jpeg', size: 500_000 }],
+    }
+
+    it('deve retornar upload URLs quando cliente tem consentimento LGPD', async () => {
+      mockRepo.findCustomerInClinic.mockResolvedValue(CUSTOMER_WITH_CONSENT)
+
+      const result = await service.requestUploadUrls({
+        clinicId: CLINIC_ID,
+        customerId: CUSTOMER_ID,
+        userId: USER_ID,
+        dto: baseDto,
+      })
+
+      expect(result.uploads).toHaveLength(1)
+      expect(result.uploads[0].uploadUrl).toBe('https://r2.example.com/upload-url')
+      expect(mockRedis.set).toHaveBeenCalledOnce()
+    })
+
+    it('deve lançar ValidationError quando cliente não tem consentimento LGPD', async () => {
+      mockRepo.findCustomerInClinic.mockResolvedValue(CUSTOMER_NO_CONSENT)
+
+      await expect(
+        service.requestUploadUrls({
+          clinicId: CLINIC_ID,
+          customerId: CUSTOMER_ID,
+          userId: USER_ID,
+          dto: baseDto,
+        }),
+      ).rejects.toThrow(ValidationError)
+    })
+
+    it('deve lançar ForbiddenError quando cliente não pertence à clínica (cross-tenant)', async () => {
+      mockRepo.findCustomerInClinic.mockResolvedValue(null)
+
+      await expect(
+        service.requestUploadUrls({
+          clinicId: CLINIC_ID,
+          customerId: CUSTOMER_ID,
+          userId: USER_ID,
+          dto: baseDto,
+        }),
+      ).rejects.toThrow(ForbiddenError)
+    })
+  })
+
+  // ── createPhotos ──────────────────────────────────────────────────────────
+
+  describe('createPhotos', () => {
+    const baseDto = {
+      photos: [{ storageKey: STORAGE_KEY, category: 'BEFORE_PHOTO' as const }],
+    }
+
+    beforeEach(() => {
+      // Redis cache válido por padrão
+      mockRedis.get.mockResolvedValue(
+        JSON.stringify({ clinicId: CLINIC_ID, customerId: CUSTOMER_ID, userId: USER_ID }),
+      )
+      mockRepo.findCustomerInClinic.mockResolvedValue(CUSTOMER_WITH_CONSENT)
+      mockRepo.createPending.mockResolvedValue(PHOTO_RECORD)
+    })
+
+    it('deve criar registros de fotos no caminho feliz', async () => {
+      const result = await service.createPhotos({
+        clinicId: CLINIC_ID,
+        customerId: CUSTOMER_ID,
+        userId: USER_ID,
+        dto: baseDto,
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe(PHOTO_ID)
+      expect(mockRepo.createPending).toHaveBeenCalledOnce()
+      expect(mockRedis.del).toHaveBeenCalledWith(`photo_upload:${STORAGE_KEY}`)
+    })
+
+    it('deve lançar ForbiddenError quando storageKey não está no Redis (expirado)', async () => {
+      mockRedis.get.mockResolvedValue(null)
+
+      await expect(
+        service.createPhotos({
+          clinicId: CLINIC_ID,
+          customerId: CUSTOMER_ID,
+          userId: USER_ID,
+          dto: baseDto,
+        }),
+      ).rejects.toThrow(ForbiddenError)
+    })
+
+    it('deve lançar ForbiddenError quando storageKey pertence a outro tenant (IDOR)', async () => {
+      mockRedis.get.mockResolvedValue(
+        JSON.stringify({ clinicId: 'other-clinic', customerId: CUSTOMER_ID, userId: USER_ID }),
+      )
+
+      await expect(
+        service.createPhotos({
+          clinicId: CLINIC_ID,
+          customerId: CUSTOMER_ID,
+          userId: USER_ID,
+          dto: baseDto,
+        }),
+      ).rejects.toThrow(ForbiddenError)
+    })
+
+    it('deve lançar ValidationError quando bodyRegion não está na lista configurada', async () => {
+      mockRepo.findClinicSettings.mockResolvedValue({
+        id: CLINIC_ID,
+        settings: { photoBodyRegions: ['Abdômen', 'Braços'] },
+      })
+
+      await expect(
+        service.createPhotos({
+          clinicId: CLINIC_ID,
+          customerId: CUSTOMER_ID,
+          userId: USER_ID,
+          dto: {
+            photos: [
+              {
+                storageKey: STORAGE_KEY,
+                category: 'BEFORE_PHOTO',
+                bodyRegion: 'Região Inválida',
+              },
+            ],
+          },
+        }),
+      ).rejects.toThrow(ValidationError)
+    })
+
+    it('deve lançar ValidationError quando sessionId não pertence ao cliente', async () => {
+      mockRepo.findSessionInClinic.mockResolvedValue(null)
+
+      await expect(
+        service.createPhotos({
+          clinicId: CLINIC_ID,
+          customerId: CUSTOMER_ID,
+          userId: USER_ID,
+          dto: {
+            photos: [
+              {
+                storageKey: STORAGE_KEY,
+                category: 'PROGRESS_PHOTO',
+                sessionId: SESSION_ID,
+              },
+            ],
+          },
+        }),
+      ).rejects.toThrow(ValidationError)
+    })
+  })
+
+  // ── deletePhoto ───────────────────────────────────────────────────────────
+
+  describe('deletePhoto', () => {
+    beforeEach(() => {
+      mockRepo.findById.mockResolvedValue(PHOTO_RECORD)
+      mockRepo.softDelete.mockResolvedValue({ ...PHOTO_RECORD, deletedAt: new Date() })
+    })
+
+    it('deve soft-deletar a foto e registrar auditoria', async () => {
+      await service.deletePhoto({
+        clinicId: CLINIC_ID,
+        customerId: CUSTOMER_ID,
+        photoId: PHOTO_ID,
+        userId: USER_ID,
+        dto: { reason: 'Foto duplicada do cliente' },
+      })
+
+      expect(mockRepo.softDelete).toHaveBeenCalledWith(
+        PHOTO_ID,
+        CLINIC_ID,
+        CUSTOMER_ID,
+        USER_ID,
+        'Foto duplicada do cliente',
+      )
+      expect(mockCreateAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'photo.DELETE' }),
+      )
+    })
+
+    it('deve lançar NotFoundError quando foto não existe', async () => {
+      mockRepo.findById.mockResolvedValue(null)
+
+      await expect(
+        service.deletePhoto({
+          clinicId: CLINIC_ID,
+          customerId: CUSTOMER_ID,
+          photoId: PHOTO_ID,
+          userId: USER_ID,
+          dto: { reason: 'Foto duplicada do cliente' },
+        }),
+      ).rejects.toThrow(NotFoundError)
+    })
+  })
+
+  // ── getBodyRegions / updateBodyRegions ────────────────────────────────────
+
+  describe('getBodyRegions', () => {
+    it('deve retornar lista vazia quando clínica não tem regiões configuradas', async () => {
+      mockRepo.findClinicSettings.mockResolvedValue({ id: CLINIC_ID, settings: null })
+
+      const result = await service.getBodyRegions(CLINIC_ID)
+      expect(result).toEqual([])
+    })
+
+    it('deve retornar regiões configuradas', async () => {
+      mockRepo.findClinicSettings.mockResolvedValue({
+        id: CLINIC_ID,
+        settings: { photoBodyRegions: ['Abdômen', 'Braços', 'Pernas'] },
+      })
+
+      const result = await service.getBodyRegions(CLINIC_ID)
+      expect(result).toEqual(['Abdômen', 'Braços', 'Pernas'])
+    })
+  })
+
+  describe('updateBodyRegions', () => {
+    it('deve persistir lista de regiões via repositório', async () => {
+      mockRepo.updateClinicSettings.mockResolvedValue(undefined)
+
+      await service.updateBodyRegions(CLINIC_ID, ['Abdômen', 'Braços'])
+
+      expect(mockRepo.updateClinicSettings).toHaveBeenCalledWith(CLINIC_ID, {
+        photoBodyRegions: ['Abdômen', 'Braços'],
+      })
+    })
+  })
+})

--- a/aesthera/apps/api/src/modules/customer-photos/customer-photos.service.ts
+++ b/aesthera/apps/api/src/modules/customer-photos/customer-photos.service.ts
@@ -1,0 +1,300 @@
+import crypto from 'node:crypto'
+import path from 'node:path'
+import { redis } from '../../database/redis/client'
+import {
+  generatePresignedGetUrl,
+  generatePresignedPutUrl,
+} from '../../integrations/r2/r2.service'
+import { createAuditLog } from '../../shared/audit'
+import { ForbiddenError, NotFoundError, ValidationError } from '../../shared/errors/app-error'
+import {
+  PHOTO_UPLOAD_URL_TTL_SECONDS,
+  type CreatePhotosDto,
+  type DeletePhotoDto,
+  type ListPhotosQueryDto,
+  type RequestUploadUrlDto,
+} from './customer-photos.dto'
+import { CustomerPhotosRepository } from './customer-photos.repository'
+
+const REDIS_KEY_PREFIX = 'photo_upload'
+const PRESIGNED_GET_TTL = 3600 // 1h para thumbnails e originais
+
+export class CustomerPhotosService {
+  private repo = new CustomerPhotosRepository()
+
+  // ─── POST /customers/:customerId/photos/upload-url ───────────────────────
+
+  async requestUploadUrls(params: {
+    clinicId: string
+    customerId: string
+    userId: string
+    dto: RequestUploadUrlDto
+    ip?: string
+  }) {
+    const { clinicId, customerId, userId, dto } = params
+
+    // 1. Verificar que o cliente pertence à clínica
+    const customer = await this.repo.findCustomerInClinic(customerId, clinicId)
+    if (!customer) throw new ForbiddenError('CROSS_TENANT_VIOLATION')
+
+    // 2. LGPD: verificar consentimento para uso de imagens corporais
+    if (!customer.bodyDataConsentAt) {
+      throw new ValidationError('Consentimento LGPD para uso de imagens corporais não encontrado')
+    }
+
+    // 3. Gerar pre-signed URLs e cachear no Redis para anti-IDOR
+    const uploads: Array<{ uploadUrl: string; storageKey: string; expiresAt: string }> = []
+
+    for (const file of dto.files) {
+      const ext = path.extname(file.filename).toLowerCase() || '.jpg'
+      const storageKey = `${clinicId}/${customerId}/${crypto.randomUUID()}${ext}`
+
+      const uploadUrl = await generatePresignedPutUrl(
+        storageKey,
+        file.mimeType,
+        PHOTO_UPLOAD_URL_TTL_SECONDS,
+      )
+
+      const expiresAt = new Date(Date.now() + PHOTO_UPLOAD_URL_TTL_SECONDS * 1000).toISOString()
+
+      // Anti-IDOR: associar storageKey → contexto no Redis
+      await redis.set(
+        `${REDIS_KEY_PREFIX}:${storageKey}`,
+        JSON.stringify({ clinicId, customerId, userId }),
+        'EX',
+        PHOTO_UPLOAD_URL_TTL_SECONDS,
+      )
+
+      uploads.push({ uploadUrl, storageKey, expiresAt })
+    }
+
+    return { uploads }
+  }
+
+  // ─── POST /customers/:customerId/photos ──────────────────────────────────
+
+  async createPhotos(params: {
+    clinicId: string
+    customerId: string
+    userId: string
+    professionalId?: string
+    dto: CreatePhotosDto
+    ip?: string
+  }) {
+    const { clinicId, customerId, userId, professionalId, dto } = params
+
+    // 1. Verificar cliente
+    const customer = await this.repo.findCustomerInClinic(customerId, clinicId)
+    if (!customer) throw new ForbiddenError('CROSS_TENANT_VIOLATION')
+
+    // 2. Buscar regiões configuradas pela clínica (para validar bodyRegion)
+    const allowedRegions = await this.getBodyRegions(clinicId)
+
+    const created = []
+
+    for (const photo of dto.photos) {
+      // 3. Anti-IDOR: validar storageKey via Redis
+      const cached = await redis.get(`${REDIS_KEY_PREFIX}:${photo.storageKey}`)
+      if (!cached) {
+        throw new ForbiddenError(`storageKey inválido ou expirado: ${photo.storageKey}`)
+      }
+      const cachedData = JSON.parse(cached) as { clinicId: string; customerId: string }
+      if (cachedData.clinicId !== clinicId || cachedData.customerId !== customerId) {
+        throw new ForbiddenError('CROSS_TENANT_VIOLATION')
+      }
+
+      // 4. Validar bodyRegion se informado e se há regiões configuradas
+      if (photo.bodyRegion && allowedRegions.length > 0) {
+        if (!allowedRegions.includes(photo.bodyRegion)) {
+          throw new ValidationError(
+            `Região corporal "${photo.bodyRegion}" não está configurada para esta clínica`,
+          )
+        }
+      }
+
+      // 5. Validar sessionId se informado
+      if (photo.sessionId) {
+        const session = await this.repo.findSessionInClinic(photo.sessionId, clinicId, customerId)
+        if (!session) {
+          throw new ValidationError('Sessão de avaliação não encontrada ou não pertence a este cliente')
+        }
+      }
+
+      // 6. Criar registro
+      const record = await this.repo.createPending({
+        clinicId,
+        customerId,
+        storageKey: photo.storageKey,
+        name: path.basename(photo.storageKey),
+        mimeType: this.mimeTypeFromKey(photo.storageKey),
+        size: 0, // tamanho real não é verificado no confirm (upload direto)
+        category: photo.category,
+        uploadedById: userId,
+        uploadedByProfessionalId: professionalId ?? undefined,
+        takenAt: photo.takenAt ? new Date(photo.takenAt) : undefined,
+        bodyRegion: photo.bodyRegion,
+        notes: photo.notes,
+        measurementSessionId: photo.sessionId,
+      })
+
+      // 7. Remover chave do Redis após consumo
+      await redis.del(`${REDIS_KEY_PREFIX}:${photo.storageKey}`)
+
+      created.push(record)
+    }
+
+    return created
+  }
+
+  // ─── GET /customers/:customerId/photos ───────────────────────────────────
+
+  async listPhotos(params: {
+    clinicId: string
+    customerId: string
+    userId: string
+    query: ListPhotosQueryDto
+    ip?: string
+  }) {
+    const { clinicId, customerId, userId, query, ip } = params
+
+    const customer = await this.repo.findCustomerInClinic(customerId, clinicId)
+    if (!customer) throw new ForbiddenError('CROSS_TENANT_VIOLATION')
+
+    const result = await this.repo.findMany(clinicId, customerId, query)
+
+    // Log de auditoria LGPD Art. 11
+    const photoIds = result.items.map((p) => p.id)
+    await createAuditLog({
+      clinicId,
+      userId,
+      action: 'photo.VIEW',
+      entityId: customerId,
+      metadata: { photoIds, page: query.page, limit: query.limit },
+      ip,
+    })
+
+    // Gerar presigned GET URLs para cada foto
+    const itemsWithUrls = await Promise.all(
+      result.items.map(async (photo) => {
+        const url = await generatePresignedGetUrl(photo.storageKey, PRESIGNED_GET_TTL)
+        return { ...photo, url, urlExpiresAt: new Date(Date.now() + PRESIGNED_GET_TTL * 1000).toISOString() }
+      }),
+    )
+
+    return { ...result, items: itemsWithUrls }
+  }
+
+  // ─── GET /customers/:customerId/photos/:photoId/url ──────────────────────
+
+  async getPhotoUrl(params: {
+    clinicId: string
+    customerId: string
+    photoId: string
+    userId: string
+    ip?: string
+  }) {
+    const { clinicId, customerId, photoId, userId, ip } = params
+
+    const photo = await this.repo.findById(photoId, clinicId, customerId)
+    if (!photo) throw new NotFoundError('Foto')
+
+    const url = await generatePresignedGetUrl(photo.storageKey, PRESIGNED_GET_TTL)
+
+    await createAuditLog({
+      clinicId,
+      userId,
+      action: 'photo.GENERATE_URL',
+      entityId: photoId,
+      ip,
+    })
+
+    return {
+      url,
+      expiresAt: new Date(Date.now() + PRESIGNED_GET_TTL * 1000).toISOString(),
+    }
+  }
+
+  // ─── DELETE /customers/:customerId/photos/:photoId ───────────────────────
+
+  async deletePhoto(params: {
+    clinicId: string
+    customerId: string
+    photoId: string
+    userId: string
+    dto: DeletePhotoDto
+    ip?: string
+  }) {
+    const { clinicId, customerId, photoId, userId, dto, ip } = params
+
+    const photo = await this.repo.findById(photoId, clinicId, customerId)
+    if (!photo) throw new NotFoundError('Foto')
+
+    const deleted = await this.repo.softDelete(photoId, clinicId, customerId, userId, dto.reason)
+    if (!deleted) throw new NotFoundError('Foto')
+
+    await createAuditLog({
+      clinicId,
+      userId,
+      action: 'photo.DELETE',
+      entityId: photoId,
+      metadata: { reason: dto.reason },
+      ip,
+    })
+
+    return deleted
+  }
+
+  // ─── Settings: regiões corporais ─────────────────────────────────────────
+
+  async getBodyRegions(clinicId: string): Promise<string[]> {
+    const clinic = await this.repo.findClinicSettings(clinicId)
+    if (!clinic) return []
+    const settings = clinic.settings as Record<string, unknown> | null
+    const regions = settings?.photoBodyRegions
+    if (!Array.isArray(regions)) return []
+    return regions as string[]
+  }
+
+  async updateBodyRegions(clinicId: string, regions: string[]): Promise<string[]> {
+    await this.repo.updateClinicSettings(clinicId, { photoBodyRegions: regions })
+    return regions
+  }
+
+  // ─── Job: limpeza do storage ──────────────────────────────────────────────
+
+  async runStorageCleanupBatch(): Promise<number> {
+    const { deleteObject } = await import('../../integrations/r2/r2.service')
+    const batch = await this.repo.findPendingStorageDeletion(100)
+    if (batch.length === 0) return 0
+
+    const deleted: string[] = []
+    for (const file of batch) {
+      try {
+        await deleteObject(file.storageKey)
+        deleted.push(file.id)
+      } catch (err) {
+        // Log e continua — próxima execução tentará novamente
+        console.error(`[photo-cleanup] Falha ao deletar ${file.storageKey}:`, err)
+      }
+    }
+
+    if (deleted.length > 0) {
+      await this.repo.markStorageDeleted(deleted)
+    }
+
+    return deleted.length
+  }
+
+  // ─── Helpers privados ────────────────────────────────────────────────────
+
+  private mimeTypeFromKey(storageKey: string): string {
+    const ext = path.extname(storageKey).toLowerCase()
+    const map: Record<string, string> = {
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.png': 'image/png',
+      '.webp': 'image/webp',
+    }
+    return map[ext] ?? 'image/jpeg'
+  }
+}

--- a/aesthera/apps/api/src/modules/customer-photos/customer-photos.service.ts
+++ b/aesthera/apps/api/src/modules/customer-photos/customer-photos.service.ts
@@ -98,8 +98,16 @@ export class CustomerPhotosService {
       if (!cached) {
         throw new ForbiddenError(`storageKey inválido ou expirado: ${photo.storageKey}`)
       }
-      const cachedData = JSON.parse(cached) as { clinicId: string; customerId: string }
-      if (cachedData.clinicId !== clinicId || cachedData.customerId !== customerId) {
+      const cachedData = JSON.parse(cached) as {
+        clinicId: string
+        customerId: string
+        userId: string
+      }
+      if (
+        cachedData.clinicId !== clinicId ||
+        cachedData.customerId !== customerId ||
+        cachedData.userId !== userId
+      ) {
         throw new ForbiddenError('CROSS_TENANT_VIOLATION')
       }
 
@@ -196,7 +204,7 @@ export class CustomerPhotosService {
     const { clinicId, customerId, photoId, userId, ip } = params
 
     const photo = await this.repo.findById(photoId, clinicId, customerId)
-    if (!photo) throw new NotFoundError('Foto')
+    if (!photo) throw new NotFoundError('CustomerPhoto')
 
     const url = await generatePresignedGetUrl(photo.storageKey, PRESIGNED_GET_TTL)
 
@@ -227,10 +235,10 @@ export class CustomerPhotosService {
     const { clinicId, customerId, photoId, userId, dto, ip } = params
 
     const photo = await this.repo.findById(photoId, clinicId, customerId)
-    if (!photo) throw new NotFoundError('Foto')
+    if (!photo) throw new NotFoundError('CustomerPhoto')
 
     const deleted = await this.repo.softDelete(photoId, clinicId, customerId, userId, dto.reason)
-    if (!deleted) throw new NotFoundError('Foto')
+    if (!deleted) throw new NotFoundError('CustomerPhoto')
 
     await createAuditLog({
       clinicId,

--- a/aesthera/apps/api/src/shared/guards/professional-customer-access.guard.ts
+++ b/aesthera/apps/api/src/shared/guards/professional-customer-access.guard.ts
@@ -9,7 +9,11 @@ import { ForbiddenError } from '../errors/app-error'
  * elegível (confirmed, in_progress ou completed) com o cliente especificado
  * em params.customerId.
  *
- * Deve ser usado após jwtProfessionalGuard.
+ * Deve ser usado após um guard de autenticação que preencha `request.user`
+ * e `request.clinicId` — nas rotas deste contexto, `jwtClinicGuard`.
+ * Quando a rota permitir múltiplos papéis (ex.: professional, admin e staff),
+ * combine com `roleGuard`; este guard aplica a restrição apenas quando
+ * `request.user.role === 'professional'`.
  * Ignorado quando role !== 'professional'.
  *
  * @example

--- a/aesthera/apps/api/src/shared/guards/professional-customer-access.guard.ts
+++ b/aesthera/apps/api/src/shared/guards/professional-customer-access.guard.ts
@@ -24,13 +24,14 @@ import { ForbiddenError } from '../errors/app-error'
  * )
  */
 export async function professionalCustomerAccessGuard(
-  request: FastifyRequest<{ Params: { customerId?: string } }>,
+  request: FastifyRequest,
   _reply: FastifyReply,
 ): Promise<void> {
   // Apenas aplicar restrição para role professional
   if (request.user.role !== 'professional') return
 
-  const customerId = request.params.customerId
+  const params = request.params as { customerId?: string }
+  const customerId = params.customerId
   if (!customerId) throw new ForbiddenError('customerId ausente')
 
   const clinicId = request.clinicId

--- a/aesthera/apps/api/src/shared/guards/professional-customer-access.guard.ts
+++ b/aesthera/apps/api/src/shared/guards/professional-customer-access.guard.ts
@@ -1,0 +1,50 @@
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { prisma } from '../../database/prisma/client'
+import { ForbiddenError } from '../errors/app-error'
+
+/**
+ * Guard reutilizável para acesso de profissional a dados de cliente.
+ *
+ * Verifica se o profissional autenticado possui ao menos um agendamento
+ * elegível (confirmed, in_progress ou completed) com o cliente especificado
+ * em params.customerId.
+ *
+ * Deve ser usado após jwtProfessionalGuard.
+ * Ignorado quando role !== 'professional'.
+ *
+ * @example
+ * app.get(
+ *   '/customers/:customerId/photos',
+ *   { preHandler: [jwtClinicGuard, professionalCustomerAccessGuard] },
+ *   handler
+ * )
+ */
+export async function professionalCustomerAccessGuard(
+  request: FastifyRequest<{ Params: { customerId?: string } }>,
+  _reply: FastifyReply,
+): Promise<void> {
+  // Apenas aplicar restrição para role professional
+  if (request.user.role !== 'professional') return
+
+  const customerId = request.params.customerId
+  if (!customerId) throw new ForbiddenError('customerId ausente')
+
+  const clinicId = request.clinicId
+  const professionalId = request.user.sub
+
+  const hasAppointment = await prisma.appointment.findFirst({
+    where: {
+      clinicId,
+      customerId,
+      professionalId,
+      status: { in: ['confirmed', 'in_progress', 'completed'] },
+    },
+    select: { id: true },
+  })
+
+  if (!hasAppointment) {
+    throw new ForbiddenError(
+      'Você não tem atendimentos com este cliente para registrar fotos',
+    )
+  }
+}

--- a/aesthera/apps/web/app/(dashboard)/customers/page.tsx
+++ b/aesthera/apps/web/app/(dashboard)/customers/page.tsx
@@ -65,6 +65,7 @@ import { BILLING_STATUS_LABEL, BILLING_STATUS_COLOR, ANAMNESIS_STATUS_LABEL, ANA
 import { SellServiceForm } from '@/components/billing/SellServiceForm'
 import { WalletOriginBadge } from '@/components/wallet/WalletOriginBadge'
 import { EvolutionTab } from '@/components/body-measurements/evolution-tab'
+import { PhotoGallery } from '@/components/customers/photos/PhotoGallery'
 import { SendRemoteSignDialog } from './_components/send-remote-sign-dialog'
 import { SendAnamnesisDialog } from '@/components/anamnesis/SendAnamnesisDialog'
 import { ResendAnamnesisDialog } from '@/components/anamnesis/ResendAnamnesisDialog'
@@ -1964,7 +1965,7 @@ function ContractsTab({ customer }: { customer: Customer }) {
 
 // ──── Customer Detail Panel ────────────────────────────────────────────────────
 
-type DetailTab = 'profile' | 'history' | 'wallet' | 'prontuario' | 'anamnese' | 'contracts' | 'evolucao'
+type DetailTab = 'profile' | 'history' | 'wallet' | 'prontuario' | 'anamnese' | 'contracts' | 'evolucao' | 'fotos'
 
 // Types for the new-entry form
 type EntryType = ClinicalRecord['type']
@@ -2267,7 +2268,7 @@ function CustomerDetail({ customer, onEdit, onClose }: { customer: Customer; onE
 
       {/* Detail tabs */}
       <div className="flex rounded-lg border overflow-hidden">
-        {([['profile', 'Dados'], ['history', 'Histórico'], ['wallet', 'Carteira'], ['prontuario', 'Prontuário'], ['anamnese', 'Anamnese'], ['contracts', 'Contratos'], ['evolucao', 'Avaliações']] as const).map(([id, label]) => (
+        {([['profile', 'Dados'], ['history', 'Histórico'], ['wallet', 'Carteira'], ['prontuario', 'Prontuário'], ['anamnese', 'Anamnese'], ['contracts', 'Contratos'], ['evolucao', 'Avaliações'], ['fotos', 'Fotos']] as const).map(([id, label]) => (
           <button
             key={id}
             type="button"
@@ -3080,6 +3081,14 @@ function CustomerDetail({ customer, onEdit, onClose }: { customer: Customer; onE
           name: customer.name,
           bodyDataConsentAt: customer.bodyDataConsentAt,
         }} />
+      )}
+
+      {/* ── Galeria de fotos ──────────────────────────────────────────── */}
+      {detailTab === 'fotos' && (
+        <PhotoGallery
+          customerId={customer.id}
+          onViewSession={() => setDetailTab('evolucao')}
+        />
       )}
 
       {deletingRecord && (

--- a/aesthera/apps/web/app/(dashboard)/settings/photos/page.tsx
+++ b/aesthera/apps/web/app/(dashboard)/settings/photos/page.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useState } from 'react'
+import { GripVertical, Loader2, Plus, X } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { usePhotoBodyRegions, useUpdatePhotoBodyRegions } from '@/lib/hooks/use-customer-photos'
+import { useRole } from '@/lib/hooks/use-role'
+
+const MAX_REGIONS = 30
+
+export default function PhotoSettingsPage() {
+  const { role } = useRole()
+  const { data: regions, isLoading, isError } = usePhotoBodyRegions()
+  const { mutateAsync: updateRegions, isPending } = useUpdatePhotoBodyRegions()
+
+  const [draft, setDraft] = useState<string[]>([])
+  const [newRegion, setNewRegion] = useState('')
+  const [isDirty, setIsDirty] = useState(false)
+
+  // Inicializa draft quando os dados carregam
+  const initialized = isDirty || draft.length > 0
+
+  const currentList = initialized ? draft : (regions ?? [])
+
+  const handleAdd = () => {
+    const trimmed = newRegion.trim()
+    if (!trimmed) return
+    if (currentList.includes(trimmed)) {
+      toast.error('Essa região já está na lista.')
+      return
+    }
+    if (currentList.length >= MAX_REGIONS) {
+      toast.error(`Máximo de ${MAX_REGIONS} regiões permitido.`)
+      return
+    }
+    const updated = [...currentList, trimmed]
+    setDraft(updated)
+    setNewRegion('')
+    setIsDirty(true)
+  }
+
+  const handleRemove = (region: string) => {
+    const updated = currentList.filter((r) => r !== region)
+    setDraft(updated)
+    setIsDirty(true)
+  }
+
+  const handleSave = async () => {
+    try {
+      await updateRegions(currentList)
+      setIsDirty(false)
+      toast.success('Regiões salvas com sucesso.')
+    } catch {
+      toast.error('Erro ao salvar. Tente novamente.')
+    }
+  }
+
+  if (role !== 'admin') {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8 text-sm text-muted-foreground">
+        Acesso restrito a administradores.
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <div>
+        <h1 className="text-xl font-semibold">Configurações de Fotos</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Configure as regiões do corpo disponíveis para classificação das fotos dos clientes.
+        </p>
+      </div>
+
+      <div className="rounded-lg border bg-card p-5">
+        <Label className="text-sm font-medium">
+          Regiões do corpo <span className="text-muted-foreground">({currentList.length}/{MAX_REGIONS})</span>
+        </Label>
+        <p className="mb-4 text-xs text-muted-foreground">
+          Essas regiões serão exibidas como opções ao adicionar novas fotos.
+        </p>
+
+        {isLoading && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Carregando...
+          </div>
+        )}
+
+        {isError && (
+          <p className="text-sm text-destructive">Erro ao carregar as configurações.</p>
+        )}
+
+        {!isLoading && !isError && (
+          <>
+            {currentList.length === 0 ? (
+              <p className="rounded-lg border bg-muted/40 py-8 text-center text-sm text-muted-foreground">
+                Nenhuma região cadastrada.
+              </p>
+            ) : (
+              <ul className="mb-4 flex flex-col gap-1">
+                {currentList.map((region) => (
+                  <li
+                    key={region}
+                    className="flex items-center justify-between rounded-md border bg-background px-3 py-2"
+                  >
+                    <div className="flex items-center gap-2">
+                      <GripVertical className="h-4 w-4 shrink-0 text-muted-foreground/50" />
+                      <span className="text-sm">{region}</span>
+                    </div>
+                    <button
+                      type="button"
+                      aria-label={`Remover ${region}`}
+                      onClick={() => handleRemove(region)}
+                      disabled={isPending}
+                      className="text-muted-foreground hover:text-destructive"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {currentList.length < MAX_REGIONS && (
+              <div className="flex gap-2">
+                <Input
+                  value={newRegion}
+                  onChange={(e) => setNewRegion(e.target.value)}
+                  placeholder="Nova região (ex.: Abdômen)"
+                  className="text-sm"
+                  onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+                  disabled={isPending}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAdd}
+                  disabled={!newRegion.trim() || isPending}
+                >
+                  <Plus className="mr-1 h-4 w-4" />
+                  Adicionar
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          disabled={!isDirty || isPending}
+          onClick={() => {
+            setDraft(regions ?? [])
+            setIsDirty(false)
+          }}
+        >
+          Descartar
+        </Button>
+        <Button disabled={!isDirty || isPending} onClick={handleSave}>
+          {isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Salvando...
+            </>
+          ) : (
+            'Salvar'
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/aesthera/apps/web/app/(dashboard)/settings/photos/page.tsx
+++ b/aesthera/apps/web/app/(dashboard)/settings/photos/page.tsx
@@ -12,7 +12,7 @@ import { useRole } from '@/lib/hooks/use-role'
 const MAX_REGIONS = 30
 
 export default function PhotoSettingsPage() {
-  const { role } = useRole()
+  const role = useRole()
   const { data: regions, isLoading, isError } = usePhotoBodyRegions()
   const { mutateAsync: updateRegions, isPending } = useUpdatePhotoBodyRegions()
 

--- a/aesthera/apps/web/components/customers/photos/PhotoCard.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoCard.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { Calendar, Link2 } from 'lucide-react'
+import { PhotoTagBadge } from './PhotoTagBadge'
+import { PHOTO_TAG_COLOR } from '@/lib/status-colors'
+import { cn } from '@/lib/utils'
+
+type PhotoCategory = keyof typeof PHOTO_TAG_COLOR
+
+export interface PhotoItem {
+  id: string
+  url: string
+  category: PhotoCategory
+  takenAt?: string | null
+  bodyRegion?: string | null
+  notes?: string | null
+  measurementSessionId?: string | null
+  uploadedByProfessional?: { id: string; name: string } | null
+}
+
+interface PhotoCardProps {
+  photo: PhotoItem
+  onClick: (photo: PhotoItem) => void
+}
+
+export function PhotoCard({ photo, onClick }: PhotoCardProps) {
+  const date = photo.takenAt
+    ? new Date(photo.takenAt).toLocaleDateString('pt-BR')
+    : null
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(photo)}
+      className={cn(
+        'group relative aspect-square w-full overflow-hidden rounded-lg border border-border bg-muted',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+      )}
+      aria-label={`Foto — ${PHOTO_TAG_COLOR[photo.category].label}${date ? ` — ${date}` : ''}`}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={photo.url}
+        alt=""
+        className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+        loading="lazy"
+      />
+
+      {/* Overlay com badges */}
+      <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-1 bg-gradient-to-t from-black/60 to-transparent p-2">
+        <PhotoTagBadge category={photo.category} />
+
+        {photo.measurementSessionId && (
+          <Link2 className="h-3.5 w-3.5 shrink-0 text-white" aria-label="Vinculada a sessão" />
+        )}
+      </div>
+
+      {date && (
+        <div className="absolute right-1 top-1 flex items-center gap-0.5 rounded bg-black/50 px-1 py-0.5">
+          <Calendar className="h-3 w-3 text-white" />
+          <span className="text-[10px] text-white">{date}</span>
+        </div>
+      )}
+    </button>
+  )
+}

--- a/aesthera/apps/web/components/customers/photos/PhotoCard.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Calendar, Link2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { PhotoTagBadge } from './PhotoTagBadge'
 import { PHOTO_TAG_COLOR } from '@/lib/status-colors'
 import { cn } from '@/lib/utils'
@@ -29,12 +30,12 @@ export function PhotoCard({ photo, onClick }: PhotoCardProps) {
     : null
 
   return (
-    <button
-      type="button"
+    <Button
+      variant="ghost"
       onClick={() => onClick(photo)}
       className={cn(
-        'group relative aspect-square w-full overflow-hidden rounded-lg border border-border bg-muted',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+        'group relative aspect-square h-auto w-full overflow-hidden rounded-lg border border-border bg-muted p-0',
+        'focus-visible:ring-2 focus-visible:ring-primary',
       )}
       aria-label={`Foto — ${PHOTO_TAG_COLOR[photo.category].label}${date ? ` — ${date}` : ''}`}
     >
@@ -51,7 +52,7 @@ export function PhotoCard({ photo, onClick }: PhotoCardProps) {
         <PhotoTagBadge category={photo.category} />
 
         {photo.measurementSessionId && (
-          <Link2 className="h-3.5 w-3.5 shrink-0 text-white" aria-label="Vinculada a sessão" />
+          <Link2 className="h-3.5 w-3.5 shrink-0 text-white" aria-label="Vinculada à sessão" />
         )}
       </div>
 
@@ -61,6 +62,6 @@ export function PhotoCard({ photo, onClick }: PhotoCardProps) {
           <span className="text-[10px] text-white">{date}</span>
         </div>
       )}
-    </button>
+    </Button>
   )
 }

--- a/aesthera/apps/web/components/customers/photos/PhotoFilterPills.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoFilterPills.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+import { PHOTO_TAG_COLOR } from '@/lib/status-colors'
+
+type PhotoCategory = keyof typeof PHOTO_TAG_COLOR
+
+const FILTER_OPTIONS: Array<{ value: PhotoCategory | 'all'; label: string }> = [
+  { value: 'all',           label: 'Todas' },
+  { value: 'BEFORE_PHOTO',  label: 'Antes' },
+  { value: 'AFTER_PHOTO',   label: 'Depois' },
+  { value: 'PROGRESS_PHOTO', label: 'Progresso' },
+  { value: 'GALLERY_PHOTO', label: 'Sem classificação' },
+]
+
+interface PhotoFilterPillsProps {
+  value: PhotoCategory | 'all'
+  onChange: (value: PhotoCategory | 'all') => void
+  takenAtFrom?: string
+  takenAtTo?: string
+  onDateFromChange?: (value: string) => void
+  onDateToChange?: (value: string) => void
+  className?: string
+}
+
+export function PhotoFilterPills({
+  value,
+  onChange,
+  takenAtFrom,
+  takenAtTo,
+  onDateFromChange,
+  onDateToChange,
+  className,
+}: PhotoFilterPillsProps) {
+  return (
+    <div className={cn('flex flex-wrap items-center gap-2', className)}>
+      {FILTER_OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => onChange(opt.value)}
+          className={cn(
+            'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+            value === opt.value
+              ? 'border-primary bg-primary text-primary-foreground'
+              : 'border-border bg-background text-muted-foreground hover:border-primary/60',
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
+
+      {onDateFromChange && (
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-muted-foreground">De</span>
+          <input
+            type="date"
+            value={takenAtFrom ?? ''}
+            onChange={(e) => onDateFromChange(e.target.value)}
+            className="rounded border border-border bg-background px-2 py-0.5 text-xs text-foreground"
+          />
+        </div>
+      )}
+
+      {onDateToChange && (
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-muted-foreground">até</span>
+          <input
+            type="date"
+            value={takenAtTo ?? ''}
+            onChange={(e) => onDateToChange(e.target.value)}
+            className="rounded border border-border bg-background px-2 py-0.5 text-xs text-foreground"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/aesthera/apps/web/components/customers/photos/PhotoFilterPills.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoFilterPills.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-import { PHOTO_TAG_COLOR } from '@/lib/status-colors'
 
-type PhotoCategory = keyof typeof PHOTO_TAG_COLOR
+type PhotoCategory =
+  | 'BEFORE_PHOTO'
+  | 'AFTER_PHOTO'
+  | 'PROGRESS_PHOTO'
+  | 'GALLERY_PHOTO'
 
 const FILTER_OPTIONS: Array<{ value: PhotoCategory | 'all'; label: string }> = [
   { value: 'all',           label: 'Todas' },

--- a/aesthera/apps/web/components/customers/photos/PhotoFilterPills.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoFilterPills.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
 type PhotoCategory =
@@ -38,19 +39,19 @@ export function PhotoFilterPills({
   return (
     <div className={cn('flex flex-wrap items-center gap-2', className)}>
       {FILTER_OPTIONS.map((opt) => (
-        <button
+        <Button
           key={opt.value}
-          type="button"
+          variant="ghost"
           onClick={() => onChange(opt.value)}
           className={cn(
-            'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+            'rounded-full border px-3 py-1 text-xs font-medium transition-colors h-auto',
             value === opt.value
-              ? 'border-primary bg-primary text-primary-foreground'
+              ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
               : 'border-border bg-background text-muted-foreground hover:border-primary/60',
           )}
         >
           {opt.label}
-        </button>
+        </Button>
       ))}
 
       {onDateFromChange && (

--- a/aesthera/apps/web/components/customers/photos/PhotoGallery.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoGallery.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ImageIcon, Loader2, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useRole } from '@/lib/hooks/use-role'
+import { useCustomerPhotos } from '@/lib/hooks/use-customer-photos'
+import type { PhotoCategory, CustomerPhoto } from '@/lib/hooks/use-customer-photos'
+import type { PHOTO_TAG_COLOR } from '@/lib/status-colors'
+import { PhotoCard } from './PhotoCard'
+import type { PhotoItem } from './PhotoCard'
+import { PhotoFilterPills } from './PhotoFilterPills'
+import { PhotoLightbox } from './PhotoLightbox'
+import { PhotoUploadSheet } from './PhotoUploadSheet'
+
+type FilterCategory = PhotoCategory | 'all'
+
+interface PhotoGalleryProps {
+  customerId: string
+  /** Callback para abrir aba Avaliações quando "Ver sessão" é clicado no lightbox */
+  onViewSession?: (sessionId: string) => void
+}
+
+function toPhotoItem(p: CustomerPhoto): PhotoItem {
+  return {
+    id: p.id,
+    url: p.url,
+    category: p.category,
+    takenAt: p.takenAt,
+    bodyRegion: p.bodyRegion,
+    notes: p.notes,
+    measurementSessionId: p.measurementSessionId,
+    uploadedByProfessional: p.uploadedByProfessional,
+  }
+}
+
+export function PhotoGallery({ customerId, onViewSession }: PhotoGalleryProps) {
+  const { role } = useRole()
+  const canUpload = role === 'admin' || role === 'staff' || role === 'professional'
+
+  const [filterCategory, setFilterCategory] = useState<FilterCategory>('all')
+  const [takenAtFrom, setTakenAtFrom] = useState('')
+  const [takenAtTo, setTakenAtTo] = useState('')
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
+  const [uploadOpen, setUploadOpen] = useState(false)
+
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  const {
+    data,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+    isLoading,
+    isError,
+    refetch,
+  } = useCustomerPhotos(customerId, {
+    category: filterCategory === 'all' ? undefined : filterCategory,
+    takenAtFrom: takenAtFrom || undefined,
+    takenAtTo: takenAtTo || undefined,
+  })
+
+  // Agrega todas as páginas em array flat
+  const photos: PhotoItem[] = (data?.pages ?? []).flatMap((page) =>
+    page.photos.map(toPhotoItem),
+  )
+
+  // IntersectionObserver para scroll infinito
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage()
+        }
+      },
+      { threshold: 0.1 },
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  const handleCardClick = useCallback(
+    (photo: PhotoItem) => {
+      const idx = photos.findIndex((p) => p.id === photo.id)
+      setLightboxIndex(idx)
+    },
+    [photos],
+  )
+
+  // Estado de carregamento inicial — skeleton grid
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-4">
+        <SkeletonFilters />
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div key={i} className="aspect-square animate-pulse rounded-lg bg-muted" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  // Estado de erro
+  if (isError) {
+    return (
+      <div className="rounded-lg border bg-card py-16 text-center text-muted-foreground">
+        <p className="mb-3 text-sm">Não foi possível carregar as fotos.</p>
+        <Button variant="outline" size="sm" onClick={() => refetch()}>
+          Tentar novamente
+        </Button>
+      </div>
+    )
+  }
+
+  // Estado vazio — sem nenhuma foto registrada
+  if (photos.length === 0 && filterCategory === 'all' && !takenAtFrom && !takenAtTo) {
+    return (
+      <div className="rounded-lg border bg-card py-16 text-center text-muted-foreground">
+        <ImageIcon className="mx-auto mb-3 h-10 w-10 opacity-40" />
+        <p className="mb-4 text-sm">Nenhuma foto registrada.</p>
+        {canUpload && (
+          <>
+            <Button variant="outline" size="sm" onClick={() => setUploadOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Adicionar primeira foto
+            </Button>
+            <PhotoUploadSheet
+              customerId={customerId}
+              open={uploadOpen}
+              onClose={() => setUploadOpen(false)}
+            />
+          </>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Barra de filtros + botão de upload */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <PhotoFilterPills
+          value={filterCategory}
+          onChange={setFilterCategory}
+          takenAtFrom={takenAtFrom}
+          takenAtTo={takenAtTo}
+          onDateFromChange={setTakenAtFrom}
+          onDateToChange={setTakenAtTo}
+        />
+
+        {canUpload && (
+          <Button size="sm" onClick={() => setUploadOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Adicionar fotos
+          </Button>
+        )}
+      </div>
+
+      {/* Estado vazio após filtro */}
+      {photos.length === 0 && (
+        <div className="rounded-lg border bg-card py-16 text-center text-muted-foreground">
+          <p className="text-sm">Nenhuma foto encontrada para os filtros selecionados.</p>
+        </div>
+      )}
+
+      {/* Grade de fotos */}
+      {photos.length > 0 && (
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
+          {photos.map((photo) => (
+            <PhotoCard key={photo.id} photo={photo} onClick={handleCardClick} />
+          ))}
+        </div>
+      )}
+
+      {/* Sentinel para scroll infinito */}
+      <div ref={sentinelRef} className="flex h-8 items-center justify-center">
+        {isFetchingNextPage && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+      </div>
+
+      {/* Lightbox */}
+      {lightboxIndex !== null && (
+        <PhotoLightbox
+          photos={photos}
+          initialIndex={lightboxIndex}
+          open={lightboxIndex !== null}
+          onClose={() => setLightboxIndex(null)}
+          onViewSession={onViewSession}
+        />
+      )}
+
+      {/* Sheet de upload */}
+      <PhotoUploadSheet
+        customerId={customerId}
+        open={uploadOpen}
+        onClose={() => setUploadOpen(false)}
+      />
+    </div>
+  )
+}
+
+// ──── Skeleton auxiliar ───────────────────────────────────────────────────────
+
+function SkeletonFilters() {
+  return (
+    <div className="flex gap-2">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="h-6 w-20 animate-pulse rounded-full bg-muted" />
+      ))}
+    </div>
+  )
+}

--- a/aesthera/apps/web/components/customers/photos/PhotoGallery.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoGallery.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/ui/button'
 import { useRole } from '@/lib/hooks/use-role'
 import { useCustomerPhotos } from '@/lib/hooks/use-customer-photos'
 import type { PhotoCategory, CustomerPhoto } from '@/lib/hooks/use-customer-photos'
-import type { PHOTO_TAG_COLOR } from '@/lib/status-colors'
 import { PhotoCard } from './PhotoCard'
 import type { PhotoItem } from './PhotoCard'
 import { PhotoFilterPills } from './PhotoFilterPills'
@@ -62,7 +61,7 @@ export function PhotoGallery({ customerId, onViewSession }: PhotoGalleryProps) {
 
   // Agrega todas as páginas em array flat
   const photos: PhotoItem[] = (data?.pages ?? []).flatMap((page) =>
-    page.photos.map(toPhotoItem),
+    page.items.map(toPhotoItem),
   )
 
   // IntersectionObserver para scroll infinito

--- a/aesthera/apps/web/components/customers/photos/PhotoGallery.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoGallery.tsx
@@ -34,7 +34,7 @@ function toPhotoItem(p: CustomerPhoto): PhotoItem {
 }
 
 export function PhotoGallery({ customerId, onViewSession }: PhotoGalleryProps) {
-  const { role } = useRole()
+  const role = useRole()
   const canUpload = role === 'admin' || role === 'staff' || role === 'professional'
 
   const [filterCategory, setFilterCategory] = useState<FilterCategory>('all')

--- a/aesthera/apps/web/components/customers/photos/PhotoLightbox.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoLightbox.tsx
@@ -1,0 +1,226 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ChevronLeft, ChevronRight, ExternalLink, Loader2, RefreshCw, X } from 'lucide-react'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { PhotoTagBadge } from './PhotoTagBadge'
+import { PHOTO_TAG_COLOR } from '@/lib/status-colors'
+import { cn } from '@/lib/utils'
+import type { PhotoItem } from './PhotoCard'
+
+interface PhotoLightboxProps {
+  photos: PhotoItem[]
+  initialIndex: number
+  open: boolean
+  onClose: () => void
+  /** Chamado quando o usuário clica em "Ver sessão" — abre aba Avaliações */
+  onViewSession?: (sessionId: string) => void
+  /** Callback para re-requisitar URL ao expirar */
+  onRefreshUrl?: (photoId: string) => Promise<string>
+}
+
+export function PhotoLightbox({
+  photos,
+  initialIndex,
+  open,
+  onClose,
+  onViewSession,
+  onRefreshUrl,
+}: PhotoLightboxProps) {
+  const [index, setIndex] = useState(initialIndex)
+  const [imgError, setImgError] = useState(false)
+  const [imgLoading, setImgLoading] = useState(true)
+  const touchStartX = useRef<number | null>(null)
+
+  const photo = photos[index]
+
+  // Sincroniza index quando o modal abre
+  useEffect(() => {
+    if (open) {
+      setIndex(initialIndex)
+      setImgError(false)
+      setImgLoading(true)
+    }
+  }, [open, initialIndex])
+
+  const goTo = useCallback(
+    (newIndex: number) => {
+      const clamped = (newIndex + photos.length) % photos.length
+      setIndex(clamped)
+      setImgError(false)
+      setImgLoading(true)
+    },
+    [photos.length],
+  )
+
+  // Navegação por teclado
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') goTo(index - 1)
+      else if (e.key === 'ArrowRight') goTo(index + 1)
+      else if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [open, index, goTo, onClose])
+
+  // Suporte a swipe mobile
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX
+  }
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return
+    const delta = e.changedTouches[0].clientX - touchStartX.current
+    if (Math.abs(delta) > 50) goTo(delta < 0 ? index + 1 : index - 1)
+    touchStartX.current = null
+  }
+
+  const handleRefresh = async () => {
+    if (!onRefreshUrl || !photo) return
+    setImgError(false)
+    setImgLoading(true)
+    try {
+      await onRefreshUrl(photo.id)
+    } catch {
+      setImgError(true)
+      setImgLoading(false)
+    }
+  }
+
+  if (!photo) return null
+
+  const date = photo.takenAt
+    ? new Date(photo.takenAt).toLocaleDateString('pt-BR')
+    : null
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent
+        className="flex h-[calc(100dvh-2rem)] max-w-5xl flex-col gap-0 overflow-hidden bg-black/95 p-0"
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-2">
+          <span className="text-xs text-white/60">
+            {index + 1} / {photos.length}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-white/80 hover:text-white"
+            onClick={onClose}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Imagem */}
+        <div className="relative flex flex-1 items-center justify-center overflow-hidden">
+          {imgLoading && !imgError && (
+            <div className="absolute inset-0 flex items-center justify-center">
+              <Loader2 className="h-8 w-8 animate-spin text-white/60" />
+              <span className="ml-2 text-sm text-white/60">Carregando...</span>
+            </div>
+          )}
+
+          {imgError ? (
+            <div className="flex flex-col items-center gap-3 text-white/60">
+              <span className="text-sm">Não foi possível carregar a foto.</span>
+              <Button variant="outline" size="sm" onClick={handleRefresh}>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Recarregar
+              </Button>
+            </div>
+          ) : (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={photo.id}
+              src={photo.url}
+              alt=""
+              className={cn(
+                'max-h-full max-w-full object-contain transition-opacity',
+                imgLoading ? 'opacity-0' : 'opacity-100',
+              )}
+              onLoad={() => setImgLoading(false)}
+              onError={() => {
+                setImgLoading(false)
+                setImgError(true)
+              }}
+            />
+          )}
+
+          {/* Setas de navegação */}
+          {photos.length > 1 && (
+            <>
+              <button
+                type="button"
+                aria-label="Foto anterior"
+                onClick={() => goTo(index - 1)}
+                className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-2 text-white hover:bg-black/70"
+              >
+                <ChevronLeft className="h-6 w-6" />
+              </button>
+              <button
+                type="button"
+                aria-label="Próxima foto"
+                onClick={() => goTo(index + 1)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-2 text-white hover:bg-black/70"
+              >
+                <ChevronRight className="h-6 w-6" />
+              </button>
+            </>
+          )}
+        </div>
+
+        {/* Painel de informações — sempre visível (não precisa de hover/mobile) */}
+        <div className="flex flex-wrap items-start gap-3 border-t border-white/10 px-4 py-3">
+          <PhotoTagBadge category={photo.category} />
+
+          {date && (
+            <span className="text-xs text-white/60">{date}</span>
+          )}
+
+          {photo.bodyRegion && (
+            <span className="text-xs text-white/60">{photo.bodyRegion}</span>
+          )}
+
+          {photo.uploadedByProfessional && (
+            <span className="text-xs text-white/60">
+              por {photo.uploadedByProfessional.name}
+            </span>
+          )}
+
+          {photo.notes && (
+            <p className="w-full text-xs text-white/70">{photo.notes}</p>
+          )}
+
+          {photo.measurementSessionId && (
+            <div className="flex w-full items-center gap-2 rounded bg-white/10 px-2 py-1.5">
+              <span className="text-xs text-white/80">
+                Vinculada à sessão de avaliação
+                {date ? ` de ${date}` : ''}
+              </span>
+              {onViewSession && (
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="h-auto p-0 text-xs text-blue-300 hover:text-blue-200"
+                  onClick={() => {
+                    onClose()
+                    onViewSession(photo.measurementSessionId!)
+                  }}
+                >
+                  Ver sessão
+                  <ExternalLink className="ml-1 h-3 w-3" />
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/aesthera/apps/web/components/customers/photos/PhotoLightbox.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoLightbox.tsx
@@ -5,7 +5,6 @@ import { ChevronLeft, ChevronRight, ExternalLink, Loader2, RefreshCw, X } from '
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { PhotoTagBadge } from './PhotoTagBadge'
-import { PHOTO_TAG_COLOR } from '@/lib/status-colors'
 import { cn } from '@/lib/utils'
 import type { PhotoItem } from './PhotoCard'
 
@@ -129,10 +128,12 @@ export function PhotoLightbox({
           {imgError ? (
             <div className="flex flex-col items-center gap-3 text-white/60">
               <span className="text-sm">Não foi possível carregar a foto.</span>
-              <Button variant="outline" size="sm" onClick={handleRefresh}>
-                <RefreshCw className="mr-2 h-4 w-4" />
-                Recarregar
-              </Button>
+              {onRefreshUrl && (
+                <Button variant="outline" size="sm" onClick={handleRefresh}>
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  Recarregar
+                </Button>
+              )}
             </div>
           ) : (
             // eslint-disable-next-line @next/next/no-img-element

--- a/aesthera/apps/web/components/customers/photos/PhotoLightbox.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoLightbox.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ChevronLeft, ChevronRight, ExternalLink, Loader2, RefreshCw, X } from 'lucide-react'
-import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { PhotoTagBadge } from './PhotoTagBadge'
 import { cn } from '@/lib/utils'
@@ -88,16 +87,17 @@ export function PhotoLightbox({
     }
   }
 
-  if (!photo) return null
+  if (!open || !photo) return null
 
   const date = photo.takenAt
     ? new Date(photo.takenAt).toLocaleDateString('pt-BR')
     : null
 
   return (
-    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent
-        className="flex h-[calc(100dvh-2rem)] max-w-5xl flex-col gap-0 overflow-hidden bg-black/95 p-0"
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/80" onClick={onClose} />
+      <div
+        className="relative z-10 flex h-[calc(100dvh-2rem)] w-full max-w-5xl flex-col gap-0 overflow-hidden rounded-lg bg-black/95"
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
@@ -221,7 +221,7 @@ export function PhotoLightbox({
             </div>
           )}
         </div>
-      </DialogContent>
-    </Dialog>
+      </div>
+    </div>
   )
 }

--- a/aesthera/apps/web/components/customers/photos/PhotoTagBadge.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoTagBadge.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+import { PHOTO_TAG_COLOR } from '@/lib/status-colors'
+
+type PhotoCategory = keyof typeof PHOTO_TAG_COLOR
+
+interface PhotoTagBadgeProps {
+  category: PhotoCategory
+  className?: string
+}
+
+export function PhotoTagBadge({ category, className }: PhotoTagBadgeProps) {
+  const config = PHOTO_TAG_COLOR[category]
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+        config.bg,
+        config.text,
+        className,
+      )}
+    >
+      {config.label}
+    </span>
+  )
+}

--- a/aesthera/apps/web/components/customers/photos/PhotoUploadSheet.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoUploadSheet.tsx
@@ -289,7 +289,6 @@ export function PhotoUploadSheet({ customerId, open, onClose }: PhotoUploadSheet
                     <Label className="text-xs">Classificação</Label>
                     <Select
                       value={sf.category}
-                      disabled={isSubmitting}
                       onValueChange={(v) => updateFile(sf.id, { category: v as PhotoCategory })}
                     >
                       <SelectTrigger className="h-8 text-xs">
@@ -324,7 +323,6 @@ export function PhotoUploadSheet({ customerId, open, onClose }: PhotoUploadSheet
                     {bodyRegions && bodyRegions.length > 0 ? (
                       <Select
                         value={sf.bodyRegion}
-                        disabled={isSubmitting}
                         onValueChange={(v) => updateFile(sf.id, { bodyRegion: v })}
                       >
                         <SelectTrigger className="h-8 text-xs">

--- a/aesthera/apps/web/components/customers/photos/PhotoUploadSheet.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoUploadSheet.tsx
@@ -149,10 +149,12 @@ export function PhotoUploadSheet({ customerId, open, onClose }: PhotoUploadSheet
             })
             updateFile(fileEntry.id, { status: 'done', progress: 100 })
             uploadResults.push({ fileEntry, storageKey, success: true })
-          } catch {
+          } catch (uploadErr: unknown) {
+            const status = axios.isAxiosError(uploadErr) ? uploadErr.response?.status : undefined
+            console.error('[photo-upload] R2 PUT error:', status, axios.isAxiosError(uploadErr) ? uploadErr.response?.data : uploadErr)
             updateFile(fileEntry.id, {
               status: 'error',
-              errorMessage: `Falha ao enviar ${fileEntry.file.name}`,
+              errorMessage: status ? `Falha ao enviar ${fileEntry.file.name} (HTTP ${status})` : `Falha ao enviar ${fileEntry.file.name}`,
             })
             uploadResults.push({ fileEntry, storageKey, success: false })
           }
@@ -292,7 +294,9 @@ export function PhotoUploadSheet({ customerId, open, onClose }: PhotoUploadSheet
                       onValueChange={(v) => updateFile(sf.id, { category: v as PhotoCategory })}
                     >
                       <SelectTrigger className="h-8 text-xs">
-                        <SelectValue />
+                        <span className="truncate text-left">
+                          {PHOTO_TAG_COLOR[sf.category as keyof typeof PHOTO_TAG_COLOR]?.label ?? sf.category}
+                        </span>
                       </SelectTrigger>
                       <SelectContent>
                         {Object.entries(PHOTO_TAG_COLOR).map(([key, cfg]) => (

--- a/aesthera/apps/web/components/customers/photos/PhotoUploadSheet.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoUploadSheet.tsx
@@ -1,0 +1,386 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { AlertCircle, CheckCircle2, Loader2, UploadCloud, X } from 'lucide-react'
+import axios from 'axios'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet'
+import { Progress } from '@/components/ui/progress'
+import { PHOTO_TAG_COLOR } from '@/lib/status-colors'
+import {
+  useRequestPhotoUploadUrls,
+  useCreatePhotos,
+  usePhotoBodyRegions,
+} from '@/lib/hooks/use-customer-photos'
+import type { PhotoCategory } from '@/lib/hooks/use-customer-photos'
+
+const ACCEPTED_TYPES = 'image/jpeg,image/png,image/webp'
+const MAX_SIZE_BYTES = 20 * 1024 * 1024 // 20 MB
+const MAX_FILES = 5
+
+interface SelectedFile {
+  id: string
+  file: File
+  category: PhotoCategory
+  bodyRegion: string
+  notes: string
+  takenAt: string
+  progress: number
+  status: 'idle' | 'uploading' | 'done' | 'error'
+  errorMessage?: string
+}
+
+interface PhotoUploadSheetProps {
+  customerId: string
+  open: boolean
+  onClose: () => void
+}
+
+export function PhotoUploadSheet({ customerId, open, onClose }: PhotoUploadSheetProps) {
+  const [selectedFiles, setSelectedFiles] = useState<SelectedFile[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const { data: bodyRegions } = usePhotoBodyRegions()
+  const { mutateAsync: requestUploadUrls } = useRequestPhotoUploadUrls(customerId)
+  const { mutateAsync: createPhotos } = useCreatePhotos(customerId)
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? [])
+    const totalAfterAdd = selectedFiles.length + files.length
+
+    if (totalAfterAdd > MAX_FILES) {
+      toast.error(`Máximo de ${MAX_FILES} arquivos por envio.`)
+    }
+
+    const toAdd = files.slice(0, MAX_FILES - selectedFiles.length)
+    const validated: SelectedFile[] = []
+    const rejected: string[] = []
+
+    for (const file of toAdd) {
+      if (file.size > MAX_SIZE_BYTES) {
+        rejected.push(`${file.name} — arquivo excede o limite de 20 MB`)
+        continue
+      }
+      if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+        rejected.push(`${file.name} — tipo de arquivo não suportado`)
+        continue
+      }
+      validated.push({
+        id: crypto.randomUUID(),
+        file,
+        category: 'GALLERY_PHOTO',
+        bodyRegion: '',
+        notes: '',
+        takenAt: new Date().toISOString().slice(0, 10),
+        progress: 0,
+        status: 'idle',
+      })
+    }
+
+    if (rejected.length > 0) {
+      toast.error(rejected.join('\n'))
+    }
+
+    setSelectedFiles((prev) => [...prev, ...validated])
+    // Reset input so the same file can be re-added after removal
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const updateFile = (id: string, patch: Partial<SelectedFile>) => {
+    setSelectedFiles((prev) => prev.map((f) => (f.id === id ? { ...f, ...patch } : f)))
+  }
+
+  const removeFile = (id: string) => {
+    setSelectedFiles((prev) => prev.filter((f) => f.id !== id))
+  }
+
+  const handleSubmit = async () => {
+    if (selectedFiles.length === 0) return
+    setIsSubmitting(true)
+
+    try {
+      // 1. Solicitar URLs pré-assinadas
+      const response = await requestUploadUrls(
+        selectedFiles.map((f) => ({ mimeType: f.file.type, size: f.file.size })),
+      )
+
+      const urlMap = new Map(response.urls.map((u) => [u.storageKey, u.uploadUrl]))
+
+      // 2. Fazer upload direto para R2
+      const uploadResults: Array<{ fileEntry: SelectedFile; storageKey: string; success: boolean }> = []
+
+      await Promise.all(
+        response.urls.map(async ({ storageKey, uploadUrl }, idx) => {
+          const fileEntry = selectedFiles[idx]
+          updateFile(fileEntry.id, { status: 'uploading', progress: 0 })
+          try {
+            await axios.put(uploadUrl, fileEntry.file, {
+              headers: { 'Content-Type': fileEntry.file.type },
+              onUploadProgress: (evt) => {
+                const pct = evt.total ? Math.round((evt.loaded * 100) / evt.total) : 0
+                updateFile(fileEntry.id, { progress: pct })
+              },
+            })
+            updateFile(fileEntry.id, { status: 'done', progress: 100 })
+            uploadResults.push({ fileEntry, storageKey, success: true })
+          } catch {
+            updateFile(fileEntry.id, {
+              status: 'error',
+              errorMessage: `Falha ao enviar ${fileEntry.file.name}`,
+            })
+            uploadResults.push({ fileEntry, storageKey, success: false })
+          }
+        }),
+      )
+
+      const successfulUploads = uploadResults.filter((r) => r.success)
+      const failedUploads = uploadResults.filter((r) => !r.success)
+
+      if (successfulUploads.length === 0) {
+        toast.error('Nenhuma foto foi enviada com sucesso.')
+        setIsSubmitting(false)
+        return
+      }
+
+      // 3. Confirmar no backend
+      await createPhotos(
+        successfulUploads.map(({ fileEntry, storageKey }) => ({
+          storageKey,
+          category: fileEntry.category,
+          takenAt: fileEntry.takenAt ? new Date(fileEntry.takenAt).toISOString() : undefined,
+          bodyRegion: fileEntry.bodyRegion || undefined,
+          notes: fileEntry.notes || undefined,
+        })),
+      )
+
+      if (failedUploads.length > 0) {
+        toast.warning(
+          `${successfulUploads.length} foto(s) salva(s). Falha em: ${failedUploads.map((r) => r.fileEntry.file.name).join(', ')}`,
+        )
+        // Remove arquivos com sucesso, mantém os com falha
+        setSelectedFiles((prev) =>
+          prev.filter((f) => failedUploads.some((r) => r.fileEntry.id === f.id)),
+        )
+      } else {
+        toast.success(
+          successfulUploads.length === 1 ? 'Foto adicionada.' : `${successfulUploads.length} fotos adicionadas.`,
+        )
+        setSelectedFiles([])
+        onClose()
+      }
+    } catch (err: unknown) {
+      const message =
+        axios.isAxiosError(err) && err.response?.data?.message
+          ? err.response.data.message
+          : 'Erro ao salvar as fotos.'
+      toast.error(message)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleOpenChange = (v: boolean) => {
+    if (!v && !isSubmitting) {
+      setSelectedFiles([])
+      onClose()
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent className="flex w-full flex-col gap-4 overflow-y-auto sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>Adicionar fotos</SheetTitle>
+          <SheetDescription>
+            Selecione até {MAX_FILES} imagens (JPEG, PNG ou WebP, máx. 20 MB cada).
+          </SheetDescription>
+        </SheetHeader>
+
+        {/* Área de seleção */}
+        <div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={ACCEPTED_TYPES}
+            multiple
+            className="hidden"
+            onChange={handleFileChange}
+            disabled={selectedFiles.length >= MAX_FILES || isSubmitting}
+          />
+          <Button
+            variant="outline"
+            className="w-full"
+            disabled={selectedFiles.length >= MAX_FILES || isSubmitting}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <UploadCloud className="mr-2 h-4 w-4" />
+            Selecionar imagens ({selectedFiles.length}/{MAX_FILES})
+          </Button>
+        </div>
+
+        {/* Lista de arquivos selecionados */}
+        {selectedFiles.length > 0 && (
+          <div className="flex flex-col gap-4">
+            {selectedFiles.map((sf) => (
+              <div key={sf.id} className="rounded-lg border border-border p-3">
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="max-w-[200px] truncate text-sm font-medium">
+                    {sf.file.name}
+                  </span>
+                  <button
+                    type="button"
+                    aria-label="Remover"
+                    onClick={() => removeFile(sf.id)}
+                    disabled={isSubmitting}
+                    className="ml-2 text-muted-foreground hover:text-destructive"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+
+                {sf.status === 'uploading' && (
+                  <Progress value={sf.progress} className="mb-2 h-1.5" />
+                )}
+
+                {sf.status === 'error' && (
+                  <div className="mb-2 flex items-center gap-1 text-xs text-destructive">
+                    <AlertCircle className="h-3.5 w-3.5" />
+                    {sf.errorMessage}
+                  </div>
+                )}
+
+                {sf.status === 'done' && (
+                  <div className="mb-2 flex items-center gap-1 text-xs text-emerald-600">
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                    Enviado
+                  </div>
+                )}
+
+                <div className="grid grid-cols-2 gap-2">
+                  {/* Classificação */}
+                  <div className="flex flex-col gap-1">
+                    <Label className="text-xs">Classificação</Label>
+                    <Select
+                      value={sf.category}
+                      disabled={isSubmitting}
+                      onValueChange={(v) => updateFile(sf.id, { category: v as PhotoCategory })}
+                    >
+                      <SelectTrigger className="h-8 text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(PHOTO_TAG_COLOR).map(([key, cfg]) => (
+                          <SelectItem key={key} value={key} className="text-xs">
+                            {cfg.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  {/* Data da foto */}
+                  <div className="flex flex-col gap-1">
+                    <Label className="text-xs">Data da foto</Label>
+                    <Input
+                      type="date"
+                      value={sf.takenAt}
+                      max={new Date().toISOString().slice(0, 10)}
+                      disabled={isSubmitting}
+                      className="h-8 text-xs"
+                      onChange={(e) => updateFile(sf.id, { takenAt: e.target.value })}
+                    />
+                  </div>
+
+                  {/* Região do corpo */}
+                  <div className="col-span-2 flex flex-col gap-1">
+                    <Label className="text-xs">Região do corpo</Label>
+                    {bodyRegions && bodyRegions.length > 0 ? (
+                      <Select
+                        value={sf.bodyRegion}
+                        disabled={isSubmitting}
+                        onValueChange={(v) => updateFile(sf.id, { bodyRegion: v })}
+                      >
+                        <SelectTrigger className="h-8 text-xs">
+                          <SelectValue placeholder="Selecione (opcional)" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {bodyRegions.map((region) => (
+                            <SelectItem key={region} value={region} className="text-xs">
+                              {region}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <Input
+                        value={sf.bodyRegion}
+                        disabled={isSubmitting}
+                        placeholder="Ex.: Abdômen (opcional)"
+                        className="h-8 text-xs"
+                        onChange={(e) => updateFile(sf.id, { bodyRegion: e.target.value })}
+                      />
+                    )}
+                  </div>
+
+                  {/* Observações */}
+                  <div className="col-span-2 flex flex-col gap-1">
+                    <Label className="text-xs">Observações</Label>
+                    <Input
+                      value={sf.notes}
+                      disabled={isSubmitting}
+                      placeholder="Opcional"
+                      className="h-8 text-xs"
+                      onChange={(e) => updateFile(sf.id, { notes: e.target.value })}
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-auto flex gap-2">
+          <Button
+            variant="outline"
+            className="flex-1"
+            disabled={isSubmitting}
+            onClick={() => handleOpenChange(false)}
+          >
+            Cancelar
+          </Button>
+          <Button
+            className="flex-1"
+            disabled={selectedFiles.length === 0 || isSubmitting}
+            onClick={handleSubmit}
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Enviando...
+              </>
+            ) : (
+              `Salvar ${selectedFiles.length > 0 ? `(${selectedFiles.length})` : ''}`
+            )}
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/aesthera/apps/web/components/customers/photos/PhotoUploadSheet.tsx
+++ b/aesthera/apps/web/components/customers/photos/PhotoUploadSheet.tsx
@@ -88,7 +88,13 @@ export function PhotoUploadSheet({ customerId, open, onClose }: PhotoUploadSheet
         category: 'GALLERY_PHOTO',
         bodyRegion: '',
         notes: '',
-        takenAt: new Date().toISOString().slice(0, 10),
+        takenAt: (() => {
+          const d = new Date()
+          const y = d.getFullYear()
+          const m = String(d.getMonth() + 1).padStart(2, '0')
+          const day = String(d.getDate()).padStart(2, '0')
+          return `${y}-${m}-${day}`
+        })(),
         progress: 0,
         status: 'idle',
       })
@@ -117,18 +123,21 @@ export function PhotoUploadSheet({ customerId, open, onClose }: PhotoUploadSheet
 
     try {
       // 1. Solicitar URLs pré-assinadas
+      const snapshotFiles = [...selectedFiles]
       const response = await requestUploadUrls(
-        selectedFiles.map((f) => ({ mimeType: f.file.type, size: f.file.size })),
+        snapshotFiles.map((f) => ({
+          filename: f.file.name,
+          mimeType: f.file.type,
+          sizeBytes: f.file.size,
+        })),
       )
-
-      const urlMap = new Map(response.urls.map((u) => [u.storageKey, u.uploadUrl]))
 
       // 2. Fazer upload direto para R2
       const uploadResults: Array<{ fileEntry: SelectedFile; storageKey: string; success: boolean }> = []
 
       await Promise.all(
-        response.urls.map(async ({ storageKey, uploadUrl }, idx) => {
-          const fileEntry = selectedFiles[idx]
+        response.uploads.map(async ({ storageKey, uploadUrl }, idx) => {
+          const fileEntry = snapshotFiles[idx]
           updateFile(fileEntry.id, { status: 'uploading', progress: 0 })
           try {
             await axios.put(uploadUrl, fileEntry.file, {
@@ -164,7 +173,7 @@ export function PhotoUploadSheet({ customerId, open, onClose }: PhotoUploadSheet
         successfulUploads.map(({ fileEntry, storageKey }) => ({
           storageKey,
           category: fileEntry.category,
-          takenAt: fileEntry.takenAt ? new Date(fileEntry.takenAt).toISOString() : undefined,
+          takenAt: fileEntry.takenAt || undefined,
           bodyRegion: fileEntry.bodyRegion || undefined,
           notes: fileEntry.notes || undefined,
         })),
@@ -244,15 +253,16 @@ export function PhotoUploadSheet({ customerId, open, onClose }: PhotoUploadSheet
                   <span className="max-w-[200px] truncate text-sm font-medium">
                     {sf.file.name}
                   </span>
-                  <button
-                    type="button"
+                  <Button
+                    variant="ghost"
+                    size="icon"
                     aria-label="Remover"
                     onClick={() => removeFile(sf.id)}
                     disabled={isSubmitting}
-                    className="ml-2 text-muted-foreground hover:text-destructive"
+                    className="ml-2 h-8 w-8 text-muted-foreground hover:text-destructive"
                   >
                     <X className="h-4 w-4" />
-                  </button>
+                  </Button>
                 </div>
 
                 {sf.status === 'uploading' && (

--- a/aesthera/apps/web/components/ui/progress.tsx
+++ b/aesthera/apps/web/components/ui/progress.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface ProgressProps {
+  value?: number
+  className?: string
+}
+
+export function Progress({ value = 0, className }: ProgressProps) {
+  const clamped = Math.min(100, Math.max(0, value))
+  return (
+    <div className={cn('h-2 w-full overflow-hidden rounded-full bg-muted', className)}>
+      <div
+        className="h-full bg-primary transition-all duration-200"
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  )
+}

--- a/aesthera/apps/web/components/ui/sheet.tsx
+++ b/aesthera/apps/web/components/ui/sheet.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface SheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  children: React.ReactNode
+}
+
+export function Sheet({ open, onOpenChange, children }: SheetProps) {
+  React.useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onOpenChange(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onOpenChange])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={() => onOpenChange(false)}
+      />
+      {children}
+    </div>
+  )
+}
+
+interface SheetContentProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export function SheetContent({ children, className }: SheetContentProps) {
+  return (
+    <div
+      className={cn(
+        'absolute inset-y-0 right-0 z-10 flex w-full flex-col bg-background shadow-xl sm:max-w-md',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+export function SheetHeader({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('flex flex-col gap-1 border-b px-6 py-4', className)}>{children}</div>
+}
+
+export function SheetTitle({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <h2 className={cn('text-base font-semibold text-foreground', className)}>{children}</h2>
+}
+
+export function SheetDescription({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <p className={cn('text-xs text-muted-foreground', className)}>{children}</p>
+}

--- a/aesthera/apps/web/lib/hooks/use-customer-photos.ts
+++ b/aesthera/apps/web/lib/hooks/use-customer-photos.ts
@@ -1,10 +1,13 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from '@/lib/api'
-import type { PHOTO_TAG_COLOR } from '@/lib/status-colors'
 
 // ──── Types ────────────────────────────────────────────────────────────────────
 
-export type PhotoCategory = keyof typeof PHOTO_TAG_COLOR
+export type PhotoCategory =
+  | 'BEFORE_PHOTO'
+  | 'AFTER_PHOTO'
+  | 'PROGRESS_PHOTO'
+  | 'GALLERY_PHOTO'
 
 export interface CustomerPhoto {
   id: string
@@ -24,7 +27,7 @@ export interface PhotoUploadUrlItem {
 }
 
 export interface RequestUploadUrlsResponse {
-  urls: PhotoUploadUrlItem[]
+  uploads: PhotoUploadUrlItem[]
 }
 
 export interface CreatePhotoItem {
@@ -33,7 +36,7 @@ export interface CreatePhotoItem {
   takenAt?: string
   bodyRegion?: string
   notes?: string
-  measurementSessionId?: string
+  sessionId?: string
 }
 
 interface ListPhotosQuery {
@@ -55,23 +58,23 @@ export function useCustomerPhotos(customerId: string, query: ListPhotosQuery = {
       if (query.bodyRegion) params.set('bodyRegion', query.bodyRegion)
       if (query.takenAtFrom) params.set('takenAtFrom', query.takenAtFrom)
       if (query.takenAtTo) params.set('takenAtTo', query.takenAtTo)
-      const { data } = await api.get<{ photos: CustomerPhoto[]; total: number; page: number; totalPages: number }>(
-        `/api/v1/customers/${customerId}/photos?${params}`,
+      const { data } = await api.get<{ items: CustomerPhoto[]; total: number; page: number; limit: number }>(
+        `/customers/${customerId}/photos?${params}`,
       )
       return data
     },
     initialPageParam: 1,
     getNextPageParam: (lastPage) =>
-      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+      lastPage.page * lastPage.limit < lastPage.total ? lastPage.page + 1 : undefined,
     enabled: Boolean(customerId),
   })
 }
 
 export function useRequestPhotoUploadUrls(customerId: string) {
   return useMutation({
-    mutationFn: async (items: Array<{ mimeType: string; size: number; quantity?: number }>) => {
+    mutationFn: async (items: Array<{ filename: string; mimeType: string; sizeBytes: number }>) => {
       const { data } = await api.post<RequestUploadUrlsResponse>(
-        `/api/v1/customers/${customerId}/photos/upload-url`,
+        `/customers/${customerId}/photos/upload-url`,
         { files: items },
       )
       return data
@@ -83,8 +86,8 @@ export function useCreatePhotos(customerId: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (photos: CreatePhotoItem[]) => {
-      const { data } = await api.post<{ photos: CustomerPhoto[] }>(
-        `/api/v1/customers/${customerId}/photos`,
+      const { data } = await api.post<CustomerPhoto[]>(
+        `/customers/${customerId}/photos`,
         { photos },
       )
       return data
@@ -99,7 +102,7 @@ export function useDeletePhoto(customerId: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async ({ photoId, reason }: { photoId: string; reason: string }) => {
-      await api.delete(`/api/v1/customers/${customerId}/photos/${photoId}`, {
+      await api.delete(`/customers/${customerId}/photos/${photoId}`, {
         data: { reason },
       })
     },
@@ -114,7 +117,7 @@ export function useGetPhotoUrl(customerId: string, photoId: string, enabled = fa
     queryKey: ['photo-url', customerId, photoId],
     queryFn: async () => {
       const { data } = await api.get<{ url: string }>(
-        `/api/v1/customers/${customerId}/photos/${photoId}/url`,
+        `/customers/${customerId}/photos/${photoId}/url`,
       )
       return data.url
     },
@@ -129,7 +132,7 @@ export function usePhotoBodyRegions() {
   return useQuery({
     queryKey: ['photo-body-regions'],
     queryFn: async () => {
-      const { data } = await api.get<{ regions: string[] }>('/api/v1/settings/photo-body-regions')
+      const { data } = await api.get<{ regions: string[] }>('/settings/photo-body-regions')
       return data.regions
     },
     staleTime: 1000 * 60 * 5,
@@ -140,7 +143,7 @@ export function useUpdatePhotoBodyRegions() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (regions: string[]) => {
-      await api.patch('/api/v1/settings/photo-body-regions', { regions })
+      await api.patch('/settings/photo-body-regions', { regions })
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['photo-body-regions'] })

--- a/aesthera/apps/web/lib/hooks/use-customer-photos.ts
+++ b/aesthera/apps/web/lib/hooks/use-customer-photos.ts
@@ -1,0 +1,149 @@
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+import type { PHOTO_TAG_COLOR } from '@/lib/status-colors'
+
+// ──── Types ────────────────────────────────────────────────────────────────────
+
+export type PhotoCategory = keyof typeof PHOTO_TAG_COLOR
+
+export interface CustomerPhoto {
+  id: string
+  category: PhotoCategory
+  takenAt: string | null
+  bodyRegion: string | null
+  notes: string | null
+  measurementSessionId: string | null
+  uploadedByProfessional: { id: string; name: string } | null
+  storageKey: string
+  url: string
+}
+
+export interface PhotoUploadUrlItem {
+  storageKey: string
+  uploadUrl: string
+}
+
+export interface RequestUploadUrlsResponse {
+  urls: PhotoUploadUrlItem[]
+}
+
+export interface CreatePhotoItem {
+  storageKey: string
+  category: PhotoCategory
+  takenAt?: string
+  bodyRegion?: string
+  notes?: string
+  measurementSessionId?: string
+}
+
+interface ListPhotosQuery {
+  category?: PhotoCategory
+  bodyRegion?: string
+  takenAtFrom?: string
+  takenAtTo?: string
+  limit?: number
+}
+
+// ──── Hooks ────────────────────────────────────────────────────────────────────
+
+export function useCustomerPhotos(customerId: string, query: ListPhotosQuery = {}) {
+  return useInfiniteQuery({
+    queryKey: ['customer-photos', customerId, query],
+    queryFn: async ({ pageParam = 1 }) => {
+      const params = new URLSearchParams({ page: String(pageParam), limit: String(query.limit ?? 24) })
+      if (query.category) params.set('category', query.category)
+      if (query.bodyRegion) params.set('bodyRegion', query.bodyRegion)
+      if (query.takenAtFrom) params.set('takenAtFrom', query.takenAtFrom)
+      if (query.takenAtTo) params.set('takenAtTo', query.takenAtTo)
+      const { data } = await api.get<{ photos: CustomerPhoto[]; total: number; page: number; totalPages: number }>(
+        `/api/v1/customers/${customerId}/photos?${params}`,
+      )
+      return data
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) =>
+      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+    enabled: Boolean(customerId),
+  })
+}
+
+export function useRequestPhotoUploadUrls(customerId: string) {
+  return useMutation({
+    mutationFn: async (items: Array<{ mimeType: string; size: number; quantity?: number }>) => {
+      const { data } = await api.post<RequestUploadUrlsResponse>(
+        `/api/v1/customers/${customerId}/photos/upload-url`,
+        { files: items },
+      )
+      return data
+    },
+  })
+}
+
+export function useCreatePhotos(customerId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (photos: CreatePhotoItem[]) => {
+      const { data } = await api.post<{ photos: CustomerPhoto[] }>(
+        `/api/v1/customers/${customerId}/photos`,
+        { photos },
+      )
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['customer-photos', customerId] })
+    },
+  })
+}
+
+export function useDeletePhoto(customerId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ photoId, reason }: { photoId: string; reason: string }) => {
+      await api.delete(`/api/v1/customers/${customerId}/photos/${photoId}`, {
+        data: { reason },
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['customer-photos', customerId] })
+    },
+  })
+}
+
+export function useGetPhotoUrl(customerId: string, photoId: string, enabled = false) {
+  return useQuery({
+    queryKey: ['photo-url', customerId, photoId],
+    queryFn: async () => {
+      const { data } = await api.get<{ url: string }>(
+        `/api/v1/customers/${customerId}/photos/${photoId}/url`,
+      )
+      return data.url
+    },
+    enabled,
+    staleTime: 1000 * 60 * 55, // 55 min — presigned URL válida por ~1h
+  })
+}
+
+// ──── Body Regions ─────────────────────────────────────────────────────────────
+
+export function usePhotoBodyRegions() {
+  return useQuery({
+    queryKey: ['photo-body-regions'],
+    queryFn: async () => {
+      const { data } = await api.get<{ regions: string[] }>('/api/v1/settings/photo-body-regions')
+      return data.regions
+    },
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useUpdatePhotoBodyRegions() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (regions: string[]) => {
+      await api.patch('/api/v1/settings/photo-body-regions', { regions })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['photo-body-regions'] })
+    },
+  })
+}

--- a/aesthera/apps/web/lib/status-colors.ts
+++ b/aesthera/apps/web/lib/status-colors.ts
@@ -96,3 +96,13 @@ export const PAYMENT_METHOD_BADGE_COLORS: Record<string, string> = {
   wallet_credit:  'bg-amber-700 text-white dark:bg-amber-800',
   wallet_voucher: 'bg-orange-700 text-white dark:bg-orange-800',
 }
+
+// ── Galeria de Fotos — Issue #163 ──────────────────────────────────────────────
+// amber-900 sobre amber-100 garante contraste WCAG AA (~7:1)
+
+export const PHOTO_TAG_COLOR = {
+  BEFORE_PHOTO:   { bg: 'bg-green-100',  text: 'text-green-800',        label: 'Antes'             },
+  AFTER_PHOTO:    { bg: 'bg-amber-100',  text: 'text-amber-900',        label: 'Depois'            },
+  PROGRESS_PHOTO: { bg: 'bg-blue-100',   text: 'text-blue-800',         label: 'Progresso'         },
+  GALLERY_PHOTO:  { bg: 'bg-muted',      text: 'text-muted-foreground', label: 'Sem classificação' },
+} as const satisfies Record<string, { bg: string; text: string; label: string }>


### PR DESCRIPTION
## Closes #163

## O que foi implementado

### Backend

| Elemento | Arquivo | Descrição |
|---|---|---|
| Migração SQL | `apps/api/prisma/migrations/20260421_.../migration.sql` | Não-destrutiva: 7 novos campos em `customer_files`, 2 valores no enum `FileCategory` |
| Schema Prisma | `apps/api/prisma/schema.prisma` | Extensão do modelo `CustomerFile` + relação com `Professional` |
| Guard | `src/shared/guards/professional-customer-access.guard.ts` | Restringe upload a profissionais com ao menos um atendimento confirmado/ativo/concluído com o cliente |
| DTOs | `src/modules/customer-photos/customer-photos.dto.ts` | Zod — validação completa de upload, listagem, deleção e body-regions |
| Repository | `src/modules/customer-photos/customer-photos.repository.ts` | Queries Prisma (paginação, soft-delete, storage cleanup, settings JSON) |
| Service | `src/modules/customer-photos/customer-photos.service.ts` | Anti-IDOR via Redis, verificação LGPD (`bodyDataConsentAt`), audit log Art. 11, job de limpeza de storage |
| Controller | `src/modules/customer-photos/customer-photos.controller.ts` | 7 endpoints REST registrados em `app.ts` |

### Frontend

| Elemento | Arquivo | Descrição |
|---|---|---|
| Cores | `lib/status-colors.ts` | `PHOTO_TAG_COLOR` com 4 categorias (WCAG AA garantido) |
| Hooks | `lib/hooks/use-customer-photos.ts` | TanStack Query v5: `useCustomerPhotos` (scroll infinito), mutations de upload/criação/deleção, body-regions |
| `PhotoTagBadge` | `components/customers/photos/` | Badge de classificação com cores de `PHOTO_TAG_COLOR` |
| `PhotoFilterPills` | `components/customers/photos/` | Pills: Todas / Antes / Depois / Progresso / Sem classificação + filtro por período |
| `PhotoCard` | `components/customers/photos/` | Thumbnail com badge, data e indicador de sessão vinculada |
| `PhotoLightbox` | `components/customers/photos/` | Modal full-screen, teclado (←→Esc), swipe mobile, infos sempre visíveis, link "Ver sessão" |
| `PhotoUploadSheet` | `components/customers/photos/` | Upload multi-arquivo direto para R2 via pre-signed URL, progress por arquivo, falha parcial mantém sheet aberto |
| `PhotoGallery` | `components/customers/photos/` | Grid + `IntersectionObserver` (scroll infinito 24/load), skeleton, empty state, estados de erro |
| Aba Fotos | `app/(dashboard)/customers/page.tsx` | Nova aba no painel de detalhes do cliente |
| Settings | `app/(dashboard)/settings/photos/page.tsx` | Gestão de regiões do corpo (máx. 30) — acesso restrito a admin |

### Testes

- 13 testes unitários cobrindo: caminho feliz, violação LGPD, cross-tenant (IDOR), Redis expirado, bodyRegion inválida, sessionId inválido, foto não encontrada, soft-delete + auditoria, getBodyRegions e updateBodyRegions.

## Checklist

- [x] Todo texto visível ao usuário está em Português do Brasil
- [x] Upload de arquivo vai **diretamente** para R2 (nunca passa pelo backend)
- [x] `accept="image/jpeg,image/png,image/webp"` — sem `capture="environment"`
- [x] Campo labelled como **"Classificação"** (não "Tag")
- [x] Multi-tenancy: todas as queries filtram por `clinicId`
- [x] IDOR: soft-delete usa `updateMany({ id, clinicId, customerId })`
- [x] LGPD: verificação de `bodyDataConsentAt` antes de gerar upload URL
- [x] Audit log em `photo.VIEW`, `photo.GENERATE_URL` e `photo.DELETE`
- [x] `PHOTO_TAG_COLOR` centralizado em `lib/status-colors.ts`
- [x] Contraste WCAG AA: `amber-900` sobre `amber-100` para badge "Depois"
- [x] Empty state com `rounded-lg border bg-card py-16 text-center`
- [x] Sem `<button>` nativo — sempre `<Button>` do design system (exceto internos de overlay)